### PR TITLE
Support RETS servers with whitespace in capabilities responses

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -382,7 +382,7 @@ module Rets
       # Feel free to make this better. It has a test.
       raw_key_values.split(/\n/).
         map  { |r| r.split(/=/, 2) }.
-        each { |k,v| h[k.strip.downcase] = v }
+        each { |k,v| h[k.strip.downcase] = v.strip }
 
       h
     end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -21,6 +21,14 @@ CAPABILITIES = <<-XML
 </RETS>
 XML
 
+CAPABILITIES_WITH_WHITESPACE = <<XML
+<RETS ReplyCode="0" ReplyText="Operation Successful">
+<RETS-RESPONSE>
+Action = /RETS/Action
+</RETS-RESPONSE>
+</RETS>
+XML
+
 # 44 is the ASCII code for comma; an invalid delimiter.
 INVALID_DELIMETER = <<-XML
 <?xml version="1.0"?>

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -181,6 +181,13 @@ class TestClient < Test::Unit::TestCase
     )
   end
 
+  def test_extract_capabilities_with_whitespace
+    assert_equal(
+      {"action" => "/RETS/Action"},
+      @client.extract_capabilities(Nokogiri.parse(CAPABILITIES_WITH_WHITESPACE))
+    )
+  end
+
   def test_capability_url_returns_parsed_url
     @client.capabilities = { "foo" => "http://example.com" }
 


### PR DESCRIPTION
Unfortunately, GTAR (Tulsa) gives a capabilities response like this:

```
<RETS ReplyCode="0" ReplyText="Operation Successful">
<RETS-RESPONSE>
Action = /RETS/Action
</RETS-RESPONSE>
</RETS>
```

Patch and test to fix that.

(BTW, your metadata stuff is cool. I'm trying to get it into rets4r, our metadata access is crap.)
