### PR TITLE
Prevent a 'stack level too deep' error.

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -34,7 +34,8 @@ module Rets
     # RETS server provides, per http://retsdoc.onconfluence.com/display/rets172/4.10+Capability+URL+List.
     def login
       request(uri.path)
-      capabilities
+      raise UnknownResponse, "Cannot read rets server capabilities." unless @capabilities
+      @capabilities
     end
 
     # Finds records.

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -207,6 +207,12 @@ class TestClient < Test::Unit::TestCase
     @client.capabilities
   end
 
+  def test_login_fails_if_cannot_read_capabilities
+    @client.stubs(:request)
+    assert_raise Rets::UnknownResponse do
+      @client.login
+    end
+  end
 
   def test_cookies?
     assert @client.cookies?({"set-cookie" => "FavoriteFruit=Plum;"})


### PR DESCRIPTION
when the client cannot read capabilities after login

This is happening for EAMLS in production.
