### PR TITLE
move error_checking to helper use for multipart parsing

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -300,7 +300,7 @@ module Rets
       if Net::HTTPUnauthorized === response
         raise AuthorizationFailure, "Authorization failed, check credentials?"
       else
-        check_errors(response)
+        ErrorChecker.check(response)
         self.capabilities = extract_capabilities(Nokogiri.parse(response.body))
       end
     end
@@ -311,31 +311,12 @@ module Rets
         handle_unauthorized_response(response)
 
       elsif Net::HTTPSuccess === response # 2xx
-        check_errors(response)
+        ErrorChecker.check(response)
       else
         raise UnknownResponse, "Unable to handle response #{response.class}"
       end
 
       return response
-    end
-
-    def check_errors(response)
-      begin
-        if !response.body.empty?
-          xml = Nokogiri::XML.parse(response.body, nil, nil, Nokogiri::XML::ParseOptions::STRICT)
-
-          rets_element = xml.xpath("/RETS")
-          reply_text = (rets_element.attr("ReplyText") || rets_element.attr("replyText")).value
-          reply_code = (rets_element.attr("ReplyCode") || rets_element.attr("replyCode")).value.to_i
-
-          if reply_code.nonzero?
-            raise InvalidRequest, "Got error code #{reply_code} (#{reply_text})."
-          end
-        end
-
-      rescue Nokogiri::XML::SyntaxError => e
-        logger.debug "Not xml"
-      end
     end
 
     def handle_cookies(response)
@@ -496,6 +477,27 @@ module Rets
       end
 
       out.join("\n")
+    end
+
+    class ErrorChecker
+      def self.check(response)
+        begin
+          if !response.body.empty?
+            xml = Nokogiri::XML.parse(response.body, nil, nil, Nokogiri::XML::ParseOptions::STRICT)
+
+            rets_element = xml.xpath("/RETS")
+            reply_text = (rets_element.attr("ReplyText") || rets_element.attr("replyText")).value
+            reply_code = (rets_element.attr("ReplyCode") || rets_element.attr("replyCode")).value.to_i
+
+            if reply_code.nonzero?
+              raise InvalidRequest, "Got error code #{reply_code} (#{reply_text})."
+            end
+          end
+
+        rescue Nokogiri::XML::SyntaxError => e
+          #Not xml
+        end
+      end
     end
 
   end

--- a/lib/rets/parser/multipart.rb
+++ b/lib/rets/parser/multipart.rb
@@ -28,8 +28,13 @@ module Rets
               next # not a valid chunk.
             end
           end
-
+        check_for_invalids_parts!(parts)
         parts
+      end
+
+      def self.check_for_invalids_parts!(parts)
+        return unless parts.length == 1 && parts.first.headers['content-type'] == 'text/xml'
+        Client::ErrorChecker.check(parts.first)
       end
     end
   end

--- a/test/test_parser_multipart.rb
+++ b/test/test_parser_multipart.rb
@@ -28,4 +28,12 @@ class TestParserMultipart < Test::Unit::TestCase
     parts = Rets::Parser::Multipart.parse(MULTIPART_RESPONSE_URLS, "rets.object.content.boundary.1330546052739")
     assert_equal 'http://foobarmls.com/RETS//MediaDisplay/98/hr2890998-1.jpg', parts[0].headers['location']
   end
+
+  def test_parse_with_error
+    raw = "\r\n--89467f8e0c6b48158c8f1883910212ec\r\nContent-Type: text/xml\r\nContent-ID: foo\r\nObject-ID: *\r\n\r\n<RETS ReplyCode=\"20403\" ReplyText=\"No Object Found\" />\r\n\r\n--89467f8e0c6b48158c8f1883910212ec--\r\n"
+    boundary = "89467f8e0c6b48158c8f1883910212ec"
+    assert_raise Rets::InvalidRequest do
+      Rets::Parser::Multipart.parse(raw, boundary)
+    end
+  end
 end


### PR DESCRIPTION
Some RETS servers return a multipart response with the first response being an xml error, this catches it.
