### PR TITLE
Gracefully handle empty metadata documents

### DIFF
--- a/lib/rets/parser/compact.rb
+++ b/lib/rets/parser/compact.rb
@@ -17,7 +17,12 @@ module Rets
           raise InvalidDelimiter, "Empty or invalid delimiter found, unable to parse."
         end
 
-        columns = doc.at("//COLUMNS").text
+        column_node = doc.at("//COLUMNS")
+        if column_node.nil?
+          columns = ''
+        else
+          columns = column_node.text
+        end
         rows    = doc.xpath("//DATA")
 
         rows.map do |data|

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -49,6 +49,12 @@ COMPACT = <<-XML
 </METADATA>
 XML
 
+
+EMPTY_COMPACT = <<-XML
+<METADATA-TABLE Resource="OpenHouse" Class="OpenHouse" Version="01.01.00000" Date="2011-07-29T12:09:16">
+</METADATA-TABLE>
+XML
+
 METADATA_UNKNOWN = <<-XML
 <?xml version="1.0"?>
 <RETS ReplyCode="0" ReplyText="Operation successful.">

--- a/test/test_parser_compact.rb
+++ b/test/test_parser_compact.rb
@@ -56,6 +56,11 @@ class TestParserCompact < Test::Unit::TestCase
     end
   end
 
+  def test_parse_empty_document
+    rows = Rets::Parser::Compact.parse_document(EMPTY_COMPACT)
+    assert_equal [], rows
+  end
+
   def test_parse_example
     rows = Rets::Parser::Compact.parse_document(Nokogiri.parse(SAMPLE_COMPACT))
 


### PR DESCRIPTION
Some mlses are sending us empty documents, this correctly handles those documents.
