### PR TITLE
allow for downcased capability names

### DIFF
--- a/lib/rets.rb
+++ b/lib/rets.rb
@@ -26,6 +26,14 @@ module Rets
       super("Got error code #{error_code} (#{reply_text})")
     end
   end
+
+  class UnknownCapabilty < ArgumentError
+    attr_reader :capability_name
+    def initialize(capability_name)
+      @capability_name = capability_name
+      super("unknown capabilitiy #{capability_name}")
+    end
+  end
 end
 
 require 'rets/client'

--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -257,7 +257,9 @@ module Rets
     end
 
     def capability_url(name)
-      val = capabilities.fetch(name)
+      val = capabilities[name] || capabilties[name.downcase]
+
+      raise UnknownCapability.new(name) unless val
 
       begin
         if val.downcase.match(/^https?:\/\//)


### PR DESCRIPTION
Check out this here monkeypatching (at least I assume it's
monkeypatching):

``` ruby
client.capablities
# => {... "search" => "something" ... }
client.capabilities['Search']
# => "something"
client.fetch('Search')
# => KeyError: key not found: "Search"
```
