### PR TITLE
GetObject takes a colon delimited set of object_ids

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -190,11 +190,7 @@ module Rets
     # resource_id  the KeyField value of the given resource instance.
     # object_id    can be "*" or a colon delimited string of integers or an array of integers.
     def object(object_id, opts = {})
-      response = case object_id
-        when String then fetch_object(object_ids, opts)
-        when Array  then fetch_object(object_ids.join(":"), opts)
-        else raise ArgumentError, "Expected instance of String or Array, but got #{object_ids.inspect}."
-      end
+      response = fetch_object(Array(object_id).join(':'), opts)
       response.body
     end
 


### PR DESCRIPTION
This function had a remark that said you could use a comma-delimited string of integers to fetch objects. RETS GetObject actually requires a colon delimited string of integers. I fixed that remark, but added the ability to pass an array of integers instead of a string.
