### PR TITLE
Add rets class description to print_tree

### DIFF
--- a/lib/rets/metadata/rets_class.rb
+++ b/lib/rets/metadata/rets_class.rb
@@ -3,12 +3,16 @@ module Rets
     class RetsClass
       attr_accessor :tables
       attr_accessor :name
+      attr_accessor :visible_name
+      attr_accessor :description
       attr_accessor :resource
 
       def initialize(rets_class_fragment, resource)
         self.resource = resource
         self.tables = []
         self.name = rets_class_fragment["ClassName"]
+        self.visible_name = rets_class_fragment["VisibleName"]
+        self.description = rets_class_fragment["Description"]
       end
 
       def self.find_table_container(metadata, resource, rets_class)
@@ -31,6 +35,8 @@ module Rets
 
       def print_tree
         puts "  Class: #{name}"
+        puts "    Visible Name: #{visible_name}"
+        puts "    Description : #{description}"
         tables.each(&:print_tree)
       end
 


### PR DESCRIPTION
Right now the human readable metadata doesn't offer much insight into what each rets class represents. This adds both the visible name and description to each rets class.
