### PR TITLE
add more fields to print_tree

### DIFF
--- a/lib/rets/metadata/lookup_type.rb
+++ b/lib/rets/metadata/lookup_type.rb
@@ -10,7 +10,7 @@ module Rets
       end
 
       def print_tree
-        puts "      #{long_value} -> #{value}"
+        puts "        #{long_value} -> #{value}"
       end
     end
   end

--- a/lib/rets/metadata/table.rb
+++ b/lib/rets/metadata/table.rb
@@ -33,6 +33,7 @@ module Rets
         puts "      StandardName: #{ table_fragment["StandardName"] }"
         puts "      Units: #{ table_fragment["Units"] }"
         puts "      Searchable: #{ table_fragment["Searchable"] }"
+        puts "      Required: #{table_fragment['Required']}"
       end
 
       def resolve(value)
@@ -67,6 +68,13 @@ module Rets
 
       def print_tree
         puts "    LookupTable: #{name}"
+        puts "      Required: #{table_fragment['Required']}"
+        puts "      Searchable: #{ table_fragment["Searchable"] }"
+        puts "      Units: #{ table_fragment["Units"] }"
+        puts "      ShortName: #{ table_fragment["ShortName"] }"
+        puts "      LongName: #{ table_fragment["LongName"] }"
+        puts "      StandardName: #{ table_fragment["StandardName"] }"
+        puts "      Types:"
 
         lookup_types.each(&:print_tree)
       end


### PR DESCRIPTION
This adds some more fields to `print_tree`, which can be very useful when detailing information about mlses. `Required` is particularly useful, as it's hard to tell which fields are needed to do a query without that field being printed.
