### PR TITLE
allow for lowercased metadata fields

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -61,7 +61,7 @@ module Rets
     end
 
     def logout
-      unless capabilities["Logout"]
+      unless capabilities["logout"]
         raise NoLogout.new('No logout method found for rets client')
       end
       http_get(capability_url("Logout"))


### PR DESCRIPTION
some mlses break with the spec here:

```
c.capabilities.keys.sort
=> ["broker",
 "getmetadata",
 "getobject",
 "login",
 "logout",
 "membername",
 "metadatatimestamp",
 "metadataversion",
 "minmetadatatimestamp",
 "search",
 "timeoutseconds",
 "user"]
```

This should work around mlses that have incorrect fields like this.
