### PR TITLE
Allow client code to set http timeout via options

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -40,6 +40,11 @@ module Rets
       else
         @http = HTTPClient.new
       end
+
+      if @options[:receive_timeout]
+        @http.receive_timeout = @options[:receive_timeout]
+      end
+
       @http.set_cookie_store(options[:cookie_store]) if options[:cookie_store]
 
       @http_client = Rets::HttpClient.new(@http, @options, @logger, @login_url)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -210,6 +210,14 @@ class TestClient < MiniTest::Test
     assert_equal response, result
   end
 
+  def test_clean_setup_with_receive_timeout
+   HTTPClient.any_instance.expects(:receive_timeout=).with(1234)
+   @client = Rets::Client.new(
+       login_url: 'http://example.com/login',
+       receive_timeout: 1234
+   )
+  end
+
   def test_clean_setup_with_proxy_auth
     @login_url = 'http://example.com/login'
     @proxy_url = 'http://example.com/proxy'
@@ -218,10 +226,11 @@ class TestClient < MiniTest::Test
     HTTPClient.any_instance.expects(:set_proxy_auth).with(@proxy_username, @proxy_password)
 
     @client = Rets::Client.new(
-      login_url: @login_url,
-      http_proxy: @proxy_url,
-      proxy_username: @proxy_username,
-      proxy_password: @proxy_password
+        login_url: @login_url,
+        http_proxy: @proxy_url,
+        proxy_username: @proxy_username,
+        proxy_password: @proxy_password
     )
   end
+
 end


### PR DESCRIPTION
Some RETS servers need more think time before sending back http response than the default receive timeout (60 seconds)
