### PR TITLE
Review: strip invalid utf8 before parsing

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -130,7 +130,7 @@ module Rets
       if opts[:count] == COUNT.only
         Parser::Compact.get_count(res.body)
       else
-        results = Parser::Compact.parse_document(res.body)
+        results = Parser::Compact.parse_document(res.body.encode("UTF-8", "binary", :invalid => :replace, :undef => :replace))
         if resolve
           rets_class = find_rets_class(opts[:search_type], opts[:class])
           decorate_results(results, rets_class)


### PR DESCRIPTION
some mlses occasionally have invalid UTF8 in the data they have
returned. This attempts to force encoding in those cases. I need to
check through the rest of the cases here
