### PR TITLE
Review: don't raise on a 401 during logout

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -74,6 +74,10 @@ module Rets
         raise NoLogout.new('No logout method found for rets client')
       end
       http_get(capability_url("Logout"))
+    rescue UnknownResponse => e
+      unless e.message.match?(/expected a 200, but got 401/)
+        raise e
+      end
     end
 
     # Finds records.


### PR DESCRIPTION
If you tell the client to logout, and it isn't actually logged in yet,
it can 401 whilst logging in too lookup the logout url. This shouldn't
as such raise an error.
