### PR TITLE
use options to add ca_certs to http_client

### DIFF
--- a/lib/rets/http_client.rb
+++ b/lib/rets/http_client.rb
@@ -7,6 +7,7 @@ module Rets
       @options = options
       @logger = logger
       @login_url = login_url
+      @options.fetch(:ca_certs, []).each {|c| @http.ssl_config.add_trust_ca(c) }
     end
 
     def http_get(url, params=nil, extra_headers={})


### PR DESCRIPTION
We found ourselves unable to connect to a new MLS without a few cert files.  This change is working in our production environment.  Let me know if you have any questions, thanks!
