### PR TITLE
support windows

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -340,7 +340,7 @@ module Rets
 
     class FakeLogger < Logger
       def initialize
-        super("/dev/null")
+        super(IO::NULL)
       end
     end
 


### PR DESCRIPTION
Windows doesn't have a /dev/null, IO::NULL uses /dev/null when available
and knows the correct replacement for windows

fixes #66
