### PR TITLE
dont retry 20201 responses

### DIFF
--- a/lib/rets.rb
+++ b/lib/rets.rb
@@ -18,6 +18,16 @@ module Rets
     end
   end
 
+  class NoRecordsFound < ArgumentError
+    ERROR_CODE = 20201
+    attr_reader :reply_text
+
+    def initialize(reply_text)
+      @reply_text = reply_text
+      super("Got error code #{ERROR_CODE} (#{reply_text})")
+    end
+  end
+
   class InvalidRequest < ArgumentError
     attr_reader :error_code, :reply_text
     def initialize(error_code, reply_text)

--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -119,8 +119,12 @@ module Rets
       begin
         find_every(opts, resolve)
       rescue NoRecordsFound => e
-        @client_progress.no_records_found
-        []
+        if opts.fetch(:no_records_not_an_error, false)
+          handle_find_failure(retries, resolve, opts, e)
+        else
+          @client_progress.no_records_found
+          []
+        end
       rescue AuthorizationFailure, InvalidRequest => e
         handle_find_failure(retries, resolve, opts, e)
       end

--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -119,10 +119,10 @@ module Rets
         find_every(opts, resolve)
       rescue NoRecordsFound => e
         if opts.fetch(:no_records_not_an_error, false)
-          handle_find_failure(retries, resolve, opts, e)
-        else
           @client_progress.no_records_found
           []
+        else
+          handle_find_failure(retries, resolve, opts, e)
         end
       rescue AuthorizationFailure, InvalidRequest => e
         handle_find_failure(retries, resolve, opts, e)

--- a/lib/rets/client_progress_reporter.rb
+++ b/lib/rets/client_progress_reporter.rb
@@ -28,6 +28,10 @@ module Rets
       @stats.count("#{@stats_prefix}find_with_retries_exceeded_retry_count")
     end
 
+    def no_records_found
+      @logger.info("Rets::Client: No Records Found")
+    end
+
     def could_not_resolve_find_metadata(key)
       @stats.count("#{@stats_prefix}could_not_resolve_find_metadata")
       @logger.warn "Rets::Client: Can't resolve find metadata for #{key.inspect}"


### PR DESCRIPTION
An example of how we could avoid retries when the server returns 20201 (similar to https://github.com/estately/rets/issues/79)