### PR TITLE
update httpclient gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rets (0.6.0.20141221225704)
+    rets (0.6.0.20141222144113)
       httpclient (~> 2.4)
       nokogiri (~> 1.5)
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ Hoe.plugin :gemspec
 Hoe.spec 'rets' do
   developer 'Estately, Inc. Open Source', 'opensource@estately.com'
 
-  extra_deps << [ "httpclient", "~> 2.3" ]
+  extra_deps << [ "httpclient", "~> 2.4" ]
   extra_deps << [ "nokogiri",   "~> 1.5" ]
 
   extra_dev_deps << [ "mocha", "~> 0.11" ]

--- a/rets.gemspec
+++ b/rets.gemspec
@@ -1,28 +1,27 @@
 # -*- encoding: utf-8 -*-
-# stub: rets 0.6.0.20141221225704 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "rets"
-  s.version = "0.6.0.20141221225704"
+  s.version = "0.6.0.20141222144113"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
   s.authors = ["Estately, Inc. Open Source"]
   s.date = "2014-12-22"
   s.description = "[![Build Status](https://secure.travis-ci.org/estately/rets.png?branch=master)](http://travis-ci.org/estately/rets)\nA pure-ruby library for fetching data from [RETS] servers.\n\n[RETS]: http://www.rets.org"
   s.email = ["opensource@estately.com"]
   s.executables = ["rets"]
   s.extra_rdoc_files = ["CHANGELOG.md", "Manifest.txt", "README.md"]
-  s.files = [".gemtest", "CHANGELOG.md", "Manifest.txt", "README.md", "Rakefile", "bin/rets", "lib/rets.rb", "lib/rets/client.rb", "lib/rets/client_progress_reporter.rb", "lib/rets/http_client.rb", "lib/rets/locking_http_client.rb", "lib/rets/measuring_http_client.rb", "lib/rets/metadata.rb", "lib/rets/metadata/containers.rb", "lib/rets/metadata/lookup_type.rb", "lib/rets/metadata/resource.rb", "lib/rets/metadata/rets_class.rb", "lib/rets/metadata/root.rb", "lib/rets/metadata/table.rb", "lib/rets/parser/compact.rb", "lib/rets/parser/multipart.rb", "test/fixtures.rb", "test/helper.rb", "test/test_client.rb", "test/test_locking_http_client.rb", "test/test_metadata.rb", "test/test_parser_compact.rb", "test/test_parser_multipart.rb", "test/vcr_cassettes/unauthorized_response.yml"]
+  s.files = ["CHANGELOG.md", "Manifest.txt", "README.md", "Rakefile", "bin/rets", "lib/rets.rb", "lib/rets/client.rb", "lib/rets/client_progress_reporter.rb", "lib/rets/http_client.rb", "lib/rets/locking_http_client.rb", "lib/rets/measuring_http_client.rb", "lib/rets/metadata.rb", "lib/rets/metadata/containers.rb", "lib/rets/metadata/lookup_type.rb", "lib/rets/metadata/resource.rb", "lib/rets/metadata/rets_class.rb", "lib/rets/metadata/root.rb", "lib/rets/metadata/table.rb", "lib/rets/parser/compact.rb", "lib/rets/parser/multipart.rb", "test/fixtures.rb", "test/helper.rb", "test/test_client.rb", "test/test_locking_http_client.rb", "test/test_metadata.rb", "test/test_parser_compact.rb", "test/test_parser_multipart.rb", "test/vcr_cassettes/unauthorized_response.yml", ".gemtest"]
   s.homepage = "http://github.com/estately/rets"
   s.rdoc_options = ["--main", "README.md"]
+  s.require_paths = ["lib"]
   s.rubyforge_project = "rets"
-  s.rubygems_version = "2.2.0"
+  s.rubygems_version = "1.8.23.2"
   s.summary = "[![Build Status](https://secure.travis-ci.org/estately/rets.png?branch=master)](http://travis-ci.org/estately/rets) A pure-ruby library for fetching data from [RETS] servers"
   s.test_files = ["test/test_client.rb", "test/test_locking_http_client.rb", "test/test_metadata.rb", "test/test_parser_compact.rb", "test/test_parser_multipart.rb"]
 
   if s.respond_to? :specification_version then
-    s.specification_version = 4
+    s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<httpclient>, ["~> 2.4"])
@@ -33,7 +32,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<webmock>, ["~> 1.8"])
       s.add_development_dependency(%q<hoe>, ["~> 3.6"])
     else
-      s.add_dependency(%q<httpclient>, ["~> 2.3"])
+      s.add_dependency(%q<httpclient>, ["~> 2.4"])
       s.add_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<mocha>, ["~> 0.11"])
@@ -42,7 +41,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<hoe>, ["~> 3.6"])
     end
   else
-    s.add_dependency(%q<httpclient>, ["~> 2.3"])
+    s.add_dependency(%q<httpclient>, ["~> 2.4"])
     s.add_dependency(%q<nokogiri>, ["~> 1.5"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<mocha>, ["~> 0.11"])


### PR DESCRIPTION
httpclient gem needs to be 2.4 or higher, otherwise it will default to using SSLv3 which makes you vulnerable to POODLE attacks. I was getting issues with an app because of gems we are using (namely Faraday) seem to dislike SSLv3 because of this vulnerability. I couldn't update the httpclient version because of the lock you have in place.

I also strongly suggest that the next version of this rets client should REQUIRE 2.4 or higher because of POODLE
