### PR TITLE
Fix for count requests with `no_records_not_an_error: true` option

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -120,7 +120,7 @@ module Rets
       rescue NoRecordsFound => e
         if opts.fetch(:no_records_not_an_error, false)
           @client_progress.no_records_found
-          []
+          opts[:count] == COUNT.only ? 0 : []
         else
           handle_find_failure(retries, resolve, opts, e)
         end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -107,13 +107,13 @@ class TestClient < MiniTest::Test
   end
 
   def test_find_does_not_retry_when_receiving_no_records_found_with_option
-    @client.stubs(:find_every).raises(Rets::NoRecordsFound.new('')).then.returns([1])
+    @client.stubs(:find_every).raises(Rets::NoRecordsFound.new(''))
 
     assert_equal [], @client.find(:all, no_records_not_an_error: true)
   end
 
   def test_find_does_not_retry_and_returns_zero_on_count_request_when_receiving_no_records_found_with_option
-    @client.stubs(:find_every).raises(Rets::NoRecordsFound.new('')).then.returns([1])
+    @client.stubs(:find_every).raises(Rets::NoRecordsFound.new(''))
 
     assert_equal 0, @client.find(:all, count: 2, no_records_not_an_error: true)
   end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -103,12 +103,19 @@ class TestClient < MiniTest::Test
   def test_find_retries_when_receiving_no_records_found
     @client.stubs(:find_every).raises(Rets::NoRecordsFound.new('')).then.returns([1])
 
-    assert_equal @client.find(:all), [1]
+    assert_equal [1], @client.find(:all)
   end
 
   def test_find_does_not_retry_when_receiving_no_records_found_with_option
     @client.stubs(:find_every).raises(Rets::NoRecordsFound.new('')).then.returns([1])
-    assert_equal @client.find(:all, no_records_not_an_error: true), []
+
+    assert_equal [], @client.find(:all, no_records_not_an_error: true)
+  end
+
+  def test_find_does_not_retry_and_returns_zero_on_count_request_when_receiving_no_records_found_with_option
+    @client.stubs(:find_every).raises(Rets::NoRecordsFound.new('')).then.returns([1])
+
+    assert_equal 0, @client.find(:all, count: 2, no_records_not_an_error: true)
   end
 
   def test_find_retries_on_errors


### PR DESCRIPTION
Added returning of 0 instead of [] for count requests with `:no_records_not_an_error` option set to `true`