### PR TITLE
Fix encoding to not assume all incoming text is ASCII

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -148,7 +148,9 @@ module Rets
       if opts[:count] == COUNT.only
         Parser::Compact.get_count(res.body)
       else
-        results = Parser::Compact.parse_document(res.body.encode("UTF-8", "binary", :invalid => :replace, :undef => :replace))
+        results = Parser::Compact.parse_document(
+          res.body.encode("UTF-8", res.body.encoding, :invalid => :replace, :undef => :replace)
+        )
         if resolve
           rets_class = find_rets_class(opts[:search_type], opts[:class])
           decorate_results(results, rets_class)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -111,7 +111,6 @@ class TestClient < MiniTest::Test
     @client.find_every({}, false)
   end
 
-
   def test_response_text_encoding_from_utf_8
     @client.stubs(:capability_url).with("Search").returns("search_url")
 
@@ -120,6 +119,18 @@ class TestClient < MiniTest::Test
     @client.stubs(:http_post).with("search_url", anything).returns(response)
 
     Rets::Parser::Compact.expects(:parse_document).with("Some string with non-ascii characters ę")
+
+    @client.find_every({}, false)
+  end
+
+  def test_response_text_encoding_from_utf_16
+    @client.stubs(:capability_url).with("Search").returns("search_url")
+
+    response = mock
+    response.stubs(:body).returns("Some string with non-utf-8 characters \xC2")
+    @client.stubs(:http_post).with("search_url", anything).returns(response)
+
+    Rets::Parser::Compact.expects(:parse_document).with("Some string with non-utf-8 characters �")
 
     @client.find_every({}, false)
   end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -99,6 +99,30 @@ class TestClient < MiniTest::Test
     end
   end
 
+  def test_response_text_encoding_from_ascii
+    @client.stubs(:capability_url).with("Search").returns("search_url")
+
+    response = mock
+    response.stubs(:body).returns(("An ascii string").encode("binary", "UTF-8"))
+    @client.stubs(:http_post).with("search_url", anything).returns(response)
+
+    Rets::Parser::Compact.expects(:parse_document).with("An ascii string")
+
+    @client.find_every({}, false)
+  end
+
+
+  def test_response_text_encoding_from_utf_8
+    @client.stubs(:capability_url).with("Search").returns("search_url")
+
+    response = mock
+    response.stubs(:body).returns("Some string with non-ascii characters ę")
+    @client.stubs(:http_post).with("search_url", anything).returns(response)
+
+    Rets::Parser::Compact.expects(:parse_document).with("Some string with non-ascii characters ę")
+
+    @client.find_every({}, false)
+  end
 
   def test_find_retries_when_receiving_no_records_found
     @client.stubs(:find_every).raises(Rets::NoRecordsFound.new('')).then.returns([1])

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -115,10 +115,10 @@ class TestClient < MiniTest::Test
     @client.stubs(:capability_url).with("Search").returns("search_url")
 
     response = mock
-    response.stubs(:body).returns("Some string with non-ascii characters ę")
+    response.stubs(:body).returns("Some string with non-ascii characters \u0119")
     @client.stubs(:http_post).with("search_url", anything).returns(response)
 
-    Rets::Parser::Compact.expects(:parse_document).with("Some string with non-ascii characters ę")
+    Rets::Parser::Compact.expects(:parse_document).with("Some string with non-ascii characters \u0119")
 
     @client.find_every({}, false)
   end
@@ -130,7 +130,7 @@ class TestClient < MiniTest::Test
     response.stubs(:body).returns("Some string with non-utf-8 characters \xC2")
     @client.stubs(:http_post).with("search_url", anything).returns(response)
 
-    Rets::Parser::Compact.expects(:parse_document).with("Some string with non-utf-8 characters �")
+    Rets::Parser::Compact.expects(:parse_document).with("Some string with non-utf-8 characters \uFFFD")
 
     @client.find_every({}, false)
   end


### PR DESCRIPTION
At the moment the response body is asumed to be ASCII. If the incomming text is UTF-8 and contains non-ASCII characters then they are replaced ```uFFFD```

This patch fixes text encoding to use the response body encoding and convert to UTF-8 from that.