### PR TITLE
Reduced memory usage on parsing metadata:

### DIFF
--- a/lib/rets/metadata/containers.rb
+++ b/lib/rets/metadata/containers.rb
@@ -14,8 +14,7 @@ module Rets
         def self.uses(*fields)
           fields.each do |field|
             define_method(field) do
-              instance_variable_get("@#{field}") ||
-                instance_variable_set("@#{field}", extract(fragment, field.to_s.capitalize))
+              fields_hash[field] || fields_hash[field] = extract(fragment, field.to_s.capitalize)
             end
           end
         end
@@ -28,6 +27,12 @@ module Rets
 
         def extract(fragment, attr)
           fragment.attr(attr)
+        end
+
+        private
+
+        def fields_hash
+          @fields ||= {}
         end
 
       end

--- a/test/test_parser_compact.rb
+++ b/test/test_parser_compact.rb
@@ -10,8 +10,8 @@ class TestParserCompact < MiniTest::Test
   def test_parse_document_uses_default_delimiter_when_none_provided
     #  we assert that the delimeter character getting to parse is a tab
     #  even though COMPACT defines no delimiter tag
-    Rets::Parser::Compact.expects(:parse).with("A\tB", "1\t2", /\t/)
-    Rets::Parser::Compact.expects(:parse).with("A\tB", "4\t5", /\t/)
+    Rets::Parser::Compact.expects(:parse_row).with(%w(A B), "1\t2", /\t/)
+    Rets::Parser::Compact.expects(:parse_row).with(%w(A B), "4\t5", /\t/)
     Rets::Parser::Compact.parse_document(COMPACT)
   end
 
@@ -30,29 +30,31 @@ class TestParserCompact < MiniTest::Test
   end
 
   def test_parse_returns_key_value_pairs
-    result = Rets::Parser::Compact.parse("A\tB", "1\t2")
+    result = Rets::Parser::Compact.parse_row(%w(A B), "1\t2")
 
     assert_equal({"A" => "1", "B" => "2"}, result)
   end
 
   # RMLS does this. :|
   def test_remaining_columns_produce_empty_string_values
-    columns = "A B C D"
-    data    = "1 2"
+    column_names = %w(A B C D)
+    data         = "1 2"
 
-    assert_equal({"A" => "1", "B" => "2", "C" => "", "D" => ""}, Rets::Parser::Compact.parse(columns, data, / /))
+    assert_equal({"A" => "1", "B" => "2", "C" => "", "D" => ""},
+                 Rets::Parser::Compact.parse_row(column_names, data, / /))
   end
 
   def test_leading_empty_columns_are_preserved_with_delimiter
-    columns = "A\tB\tC\tD"
-    data    = "\t\t3\t4" # first two columns are empty data.
+    column_names = %w(A B C D)
+    data         = "\t\t3\t4" # first two columns are empty data.
 
-    assert_equal({"A" => "", "B" => "", "C" => "3", "D" => "4"}, Rets::Parser::Compact.parse(columns, data, /\t/))
+    assert_equal({"A" => "", "B" => "", "C" => "3", "D" => "4"},
+                 Rets::Parser::Compact.parse_row(column_names, data, /\t/))
   end
 
   def test_parse_only_accepts_regexp
     assert_raises ArgumentError do
-      Rets::Parser::Compact.parse("a", "b", " ")
+      Rets::Parser::Compact.parse_row(["a"], "b", " ")
     end
   end
 


### PR DESCRIPTION
- Changed constructor of metadata container to not generate new strings;
- Fixed reparsing column names for each row of COMPACT metadata;
- Removed generating of unneeded trailing empty strings on parsing row data.