### PR TITLE
HTML unescape rets responses

### DIFF
--- a/lib/rets/parser/compact.rb
+++ b/lib/rets/parser/compact.rb
@@ -6,7 +6,7 @@ module Rets
       InvalidDelimiter = Class.new(ArgumentError)
 
       def self.parse_document(xml)
-        doc = Nokogiri.parse(xml.to_s)
+        doc = Nokogiri.parse(CGI.unescapeHTML(xml.to_s))
 
         delimiter = doc.at("//DELIMITER")
         delimiter = delimiter ? Regexp.new(Regexp.escape(delimiter.attr(:value).to_i.chr)) : TAB

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -205,7 +205,7 @@ SAMPLE_COMPACT_2 = <<XML
     <DATA>		15n1172	ZipCode_f1172		Zip	ZipCo_1172	Zip	50	Character	0	1			0			0		0			0	0		0			0	</DATA>
     <DATA>		15n1177	ADDRESS1_f1177		Address Line 1	ADDRE_1177	Address1	50	Character	0	1			0			0		0			0	0		0			0	</DATA>
     <DATA>		15n1182	MLSYN_f1182		MLS Y/N	MLSYN_1182	MLSYN	1	Character	0	1			0			0		0			0	0		0			0	</DATA>
-    <DATA>		15n1184	OFFICENAME_f1184	Name	Office Name	OFFIC_1184	Office Name	50	Character	0	1			0			0		0			0	0		0			0	</DATA>
+    <DATA>		15n1184	OFFICENAME_f1184	Office Name	Office&#x2019;s Name	OFFIC_1184	Office Name	50	Character	0	1			0			0		0			0	0		0			0	</DATA>
     <DATA>		15n1193	OfficeCode_f1193	OfficeID	Office Code	Offic_1193	Office Code	12	Character	0	1			0			0		0			0	0		0			1	</DATA>
   </METADATA-TABLE>
 </RETS>

--- a/test/test_parser_compact.rb
+++ b/test/test_parser_compact.rb
@@ -85,4 +85,10 @@ class TestParserCompact < MiniTest::Test
     assert_equal "", rows.first["ModTimeStamp"]
   end
 
+  def test_parse_html_encoded_chars
+    rows = Rets::Parser::Compact.parse_document(Nokogiri.parse(SAMPLE_COMPACT_2))
+
+    assert_equal "Office Name", rows[13]["StandardName"]
+    assert_equal "Office\u2019s Name", rows[13]["LongName"]
+  end
 end


### PR DESCRIPTION
We've encountered some mlses sending their responses with HTML encoded characters.

One could argue whether this should be handled in this gem but I figured this PR should start a discussion at least.