### PR TITLE
update httpclient

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rets (0.7.0.20150116133928)
-      httpclient (~> 2.4)
+      httpclient (~> 2.6)
       nokogiri (~> 1.5)
 
 GEM

--- a/rets.gemspec
+++ b/rets.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httpclient>, ["~> 2.4"])
+      s.add_runtime_dependency(%q<httpclient>, ["~> 2.6"])
       s.add_runtime_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<mocha>, ["~> 0.11"])
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<webmock>, ["~> 1.8"])
       s.add_development_dependency(%q<hoe>, ["~> 3.6"])
     else
-      s.add_dependency(%q<httpclient>, ["~> 2.4"])
+      s.add_dependency(%q<httpclient>, ["~> 2.6"])
       s.add_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<mocha>, ["~> 0.11"])
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<hoe>, ["~> 3.6"])
     end
   else
-    s.add_dependency(%q<httpclient>, ["~> 2.4"])
+    s.add_dependency(%q<httpclient>, ["~> 2.6"])
     s.add_dependency(%q<nokogiri>, ["~> 1.5"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<mocha>, ["~> 0.11"])


### PR DESCRIPTION
I wrote https://github.com/estately/rets/issues/105 without realizing we were using an outdated version of `http-client` which does not use `http-cookie`, instead it has a rather large custom implementation (https://github.com/nahi/httpclient/blob/v2.4.0/lib/httpclient/cookie.rb#L212-L4370) which seems less open to changing the storage.
