### PR TITLE
html escape response properly

### DIFF
--- a/lib/rets/parser/compact.rb
+++ b/lib/rets/parser/compact.rb
@@ -32,7 +32,7 @@ module Rets
       def self.parse_row(column_names, data, delimiter = TAB)
         raise ArgumentError, "Delimiter must be a regular expression" unless Regexp === delimiter
 
-        data_values = data.split(delimiter)
+        data_values = data.split(delimiter).map { |x| CGI.unescapeHTML(x) }
 
         zipped_key_values = column_names.zip(data_values).map { |k, v| [k.freeze, v.to_s] }
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -205,7 +205,7 @@ SAMPLE_COMPACT_2 = <<XML
     <DATA>		15n1172	ZipCode_f1172		Zip	ZipCo_1172	Zip	50	Character	0	1			0			0		0			0	0		0			0	</DATA>
     <DATA>		15n1177	ADDRESS1_f1177		Address Line 1	ADDRE_1177	Address1	50	Character	0	1			0			0		0			0	0		0			0	</DATA>
     <DATA>		15n1182	MLSYN_f1182		MLS Y/N	MLSYN_1182	MLSYN	1	Character	0	1			0			0		0			0	0		0			0	</DATA>
-    <DATA>		15n1184	OFFICENAME_f1184	Name	Office Name	OFFIC_1184	Office Name	50	Character	0	1			0			0		0			0	0		0			0	</DATA>
+    <DATA>		15n1184	OFFICENAME_f1184	Office Name	Office&#x2019;s Name	OFFIC_1184	Office Name	50	Character	0	1			0			0		0			0	0		0			0	</DATA>
     <DATA>		15n1193	OfficeCode_f1193	OfficeID	Office Code	Offic_1193	Office Code	12	Character	0	1			0			0		0			0	0		0			1	</DATA>
   </METADATA-TABLE>
 </RETS>
@@ -226,4 +226,20 @@ XHTML_AUTH_FAILURE = <<EOF
 <p>You do not have permission to view this directory or page using the credentials that you supplied.</p>
 </body>
 </html>
+EOF
+
+SAMPLE_COMPACT_WITH_SPECIAL_CHARS = <<EOF
+<RETS ReplyCode=\"0\" ReplyText=\"Operation Success.\">
+  <DELIMITER value=\"09\" />
+  <COLUMNS>	PublicRemarksNew	WindowCoverings	YearBuilt	Zoning	ZoningCompatibleYN	</COLUMNS>
+  <DATA>	porte-coch&amp;#xE8;re welcomes 		1999	00		</DATA>
+</RETS>
+EOF
+
+SAMPLE_COMPACT_WITH_SPECIAL_CHARS_2 = <<EOF
+<RETS ReplyCode=\"0\" ReplyText=\"Operation Success.\">
+  <DELIMITER value=\"09\" />
+  <COLUMNS>	PublicRemarksNew	WindowCoverings	YearBuilt	Zoning	ZoningCompatibleYN	</COLUMNS>
+  <DATA>	text with &lt;tag&gt;		1999	00		</DATA>
+</RETS>
 EOF

--- a/test/test_parser_compact.rb
+++ b/test/test_parser_compact.rb
@@ -85,4 +85,15 @@ class TestParserCompact < MiniTest::Test
     assert_equal "", rows.first["ModTimeStamp"]
   end
 
+  def test_parse_html_encoded_chars
+    rows = Rets::Parser::Compact.parse_document(SAMPLE_COMPACT_WITH_SPECIAL_CHARS)
+
+    assert_equal "porte-coch\u{E8}re welcomes ", rows.last["PublicRemarksNew"]
+  end
+
+  def test_parse_html_encoded_chars_2
+    rows = Rets::Parser::Compact.parse_document(SAMPLE_COMPACT_WITH_SPECIAL_CHARS_2)
+
+    assert_equal "text with <tag>", rows.last["PublicRemarksNew"]
+  end
 end


### PR DESCRIPTION
https://github.com/estately/rets/pull/104 caused issues with some mlses.

This moves the unecsaping to after Nokigiri parses (and xml-unescapes the documents). It also has better tests that fail properly.