### PR TITLE
Update json to fix "bundle install" failure in Ruby 2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
       hoe (~> 3.0)
       travis-lint (~> 1.2)
     httpclient (2.6.0.1)
-    json (1.8.0)
+    json (1.8.2)
     metaclass (0.0.1)
     mini_portile (0.6.2)
     minitest (5.0.3)


### PR DESCRIPTION
In Ruby 2.2, `bundle install` fails because the json gem doesn't build:

```
$ bundle install
Fetching gem metadata from https://rubygems.org/............
Fetching version metadata from https://rubygems.org/..
Resolving dependencies...
Using rake 10.0.4
Using addressable 2.3.4
Using crack 0.3.2
Using hashr 0.0.22
Using hoe 3.6.2
Using hoe-gemspec 1.0.0
Using travis-lint 1.7.0
Using hoe-travis 1.2
Using httpclient 2.6.0.1

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /home/wayne/.rvm/rubies/ruby-2.2.1/bin/ruby -r ./siteconf20150524-7855-al803k.rb extconf.rb 
creating Makefile

make "DESTDIR=" clean

make "DESTDIR="
compiling generator.c
In file included from generator.c:1:0:
../fbuffer/fbuffer.h: In function ‘fbuffer_to_s’:
../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                               ^
../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                    ^
Makefile:237: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/wayne/.rvm/gems/ruby-2.2.1/gems/json-1.8.0 for inspection.
Results logged to /home/wayne/.rvm/gems/ruby-2.2.1/extensions/x86_64-linux/2.2.0/json-1.8.0/gem_make.out
An error occurred while installing json (1.8.0), and Bundler cannot continue.
Make sure that `gem install json -v '1.8.0'` succeeds before bundling.
```

This patch upgrades the json gem to 1.8.2, which fixes that problem.