### PR TITLE
Print metadata to a file

### DIFF
--- a/lib/rets/metadata/lookup_type.rb
+++ b/lib/rets/metadata/lookup_type.rb
@@ -9,8 +9,11 @@ module Rets
         self.long_value  = lookup_type_fragment["LongValue"]
       end
 
-      def print_tree
-        puts "        #{long_value} -> #{value}"
+      # Print the tree to a file
+      #
+      # [out] The file to print to.  Defaults to $stdout.
+      def print_tree(out = $stdout)
+        out.puts "        #{long_value} -> #{value}"
       end
     end
   end

--- a/lib/rets/metadata/resource.rb
+++ b/lib/rets/metadata/resource.rb
@@ -69,10 +69,14 @@ module Rets
         nil
       end
 
-      def print_tree
-        puts "Resource: #{id} (Key Field: #{key_field})"
-
-        rets_classes.each(&:print_tree)
+      # Print the tree to a file
+      #
+      # [out] The file to print to.  Defaults to $stdout.
+      def print_tree(out = $stdout)
+        out.puts "Resource: #{id} (Key Field: #{key_field})"
+        rets_classes.each do |rets_class|
+          rets_class.print_tree(out)
+        end
       end
 
       def find_rets_class(rets_class_name)

--- a/lib/rets/metadata/rets_class.rb
+++ b/lib/rets/metadata/rets_class.rb
@@ -33,11 +33,16 @@ module Rets
         rets_class
       end
 
-      def print_tree
-        puts "  Class: #{name}"
-        puts "    Visible Name: #{visible_name}"
-        puts "    Description : #{description}"
-        tables.each(&:print_tree)
+      # Print the tree to a file
+      #
+      # [out] The file to print to.  Defaults to $stdout.
+      def print_tree(out = $stdout)
+        out.puts "  Class: #{name}"
+        out.puts "    Visible Name: #{visible_name}"
+        out.puts "    Description : #{description}"
+        tables.each do |table|
+          table.print_tree(out)
+        end
       end
 
       def find_table(name)

--- a/lib/rets/metadata/root.rb
+++ b/lib/rets/metadata/root.rb
@@ -106,9 +106,12 @@ module Rets
         @tree ||= build_tree
       end
 
-      def print_tree
+      # Print the tree to a file
+      #
+      # [out] The file to print to.  Defaults to $stdout.
+      def print_tree(out = $stdout)
         tree.each do |name, value|
-          value.print_tree
+          value.print_tree(out)
         end
       end
 

--- a/lib/rets/metadata/table.rb
+++ b/lib/rets/metadata/table.rb
@@ -28,15 +28,18 @@ module Rets
         self.long_name = table_fragment["LongName"]
       end
 
-      def print_tree
-        puts "    Table: #{name}"
-        puts "      Resource: #{resource.id}"
-        puts "      ShortName: #{ table_fragment["ShortName"] }"
-        puts "      LongName: #{ table_fragment["LongName"] }"
-        puts "      StandardName: #{ table_fragment["StandardName"] }"
-        puts "      Units: #{ table_fragment["Units"] }"
-        puts "      Searchable: #{ table_fragment["Searchable"] }"
-        puts "      Required: #{table_fragment['Required']}"
+      # Print the tree to a file
+      #
+      # [out] The file to print to.  Defaults to $stdout.
+      def print_tree(out = $stdout)
+        out.puts "    Table: #{name}"
+        out.puts "      Resource: #{resource.id}"
+        out.puts "      ShortName: #{ table_fragment["ShortName"] }"
+        out.puts "      LongName: #{ table_fragment["LongName"] }"
+        out.puts "      StandardName: #{ table_fragment["StandardName"] }"
+        out.puts "      Units: #{ table_fragment["Units"] }"
+        out.puts "      Searchable: #{ table_fragment["Searchable"] }"
+        out.puts "      Required: #{table_fragment['Required']}"
       end
 
       def resolve(value)
@@ -69,18 +72,23 @@ module Rets
         resource.lookup_types[lookup_name]
       end
 
-      def print_tree
-        puts "    LookupTable: #{name}"
-        puts "      Resource: #{resource.id}"
-        puts "      Required: #{table_fragment['Required']}"
-        puts "      Searchable: #{ table_fragment["Searchable"] }"
-        puts "      Units: #{ table_fragment["Units"] }"
-        puts "      ShortName: #{ table_fragment["ShortName"] }"
-        puts "      LongName: #{ table_fragment["LongName"] }"
-        puts "      StandardName: #{ table_fragment["StandardName"] }"
-        puts "      Types:"
+      # Print the tree to a file
+      #
+      # [out] The file to print to.  Defaults to $stdout.
+      def print_tree(out = $stdout)
+        out.puts "    LookupTable: #{name}"
+        out.puts "      Resource: #{resource.id}"
+        out.puts "      Required: #{table_fragment['Required']}"
+        out.puts "      Searchable: #{ table_fragment["Searchable"] }"
+        out.puts "      Units: #{ table_fragment["Units"] }"
+        out.puts "      ShortName: #{ table_fragment["ShortName"] }"
+        out.puts "      LongName: #{ table_fragment["LongName"] }"
+        out.puts "      StandardName: #{ table_fragment["StandardName"] }"
+        out.puts "      Types:"
 
-        lookup_types.each(&:print_tree)
+        lookup_types.each do |lookup_type|
+          lookup_type.print_tree(out)
+        end
       end
 
       def lookup_type(value)


### PR DESCRIPTION
The metadata #print_tree methods print to $stdout.  This backward-compatible change allows the caller to specify an optional file to which the tree is printed.  If the file is not given, the tree is printed to $stdout, as before.
