### PR TITLE
Update httpclient version to 2.6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,8 @@ Hoe.plugin :gemspec
 Hoe.spec 'rets' do
   developer 'Estately, Inc. Open Source', 'opensource@estately.com'
 
-  extra_deps << [ "httpclient", "~> 2.4.0" ]
+  extra_deps << [ "httpclient", "~> 2.6.0" ]
+  extra_deps << [ "http-cookie", "~> 1.0.0" ]
   extra_deps << [ "nokogiri",   "~> 1.5" ]
 
   extra_dev_deps << [ "mocha", "~> 0.11" ]

--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -1,3 +1,4 @@
+require 'http-cookie'
 require 'httpclient'
 require 'logger'
 

--- a/lib/rets/http_client.rb
+++ b/lib/rets/http_client.rb
@@ -82,9 +82,12 @@ module Rets
     end
 
     def http_cookie(name)
-      http.cookies.each do |c|
-        return c.value if c.name.downcase == name.downcase && c.match?(URI.parse(login_url))
+      @http.cookie_manager.cookies(login_url).each do |c|
+        if c.name.downcase == name.downcase
+          return c.value
+        end
       end
+
       nil
     end
   end

--- a/rets.gemspec
+++ b/rets.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httpclient>, ["~> 2.4.0"])
+      s.add_runtime_dependency(%q<httpclient>, ["~> 2.6.0"])
+      s.add_runtime_dependency(%q<http-cookie>, ["~> 1.0.0"])
       s.add_runtime_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<mocha>, ["~> 0.11"])
@@ -32,7 +33,8 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<webmock>, ["~> 1.8"])
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
     else
-      s.add_dependency(%q<httpclient>, ["~> 2.4.0"])
+      s.add_dependency(%q<httpclient>, ["~> 2.6.0"])
+      s.add_dependency(%q<http-cookie>, ["~> 1.0.0"])
       s.add_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<mocha>, ["~> 0.11"])
@@ -41,7 +43,8 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<hoe>, ["~> 3.13"])
     end
   else
-    s.add_dependency(%q<httpclient>, ["~> 2.4.0"])
+    s.add_dependency(%q<httpclient>, ["~> 2.6.0"])
+    s.add_dependency(%q<http-cookie>, ["~> 1.0.0"])
     s.add_dependency(%q<nokogiri>, ["~> 1.5"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<mocha>, ["~> 0.11"])

--- a/test/test_http_client.rb
+++ b/test/test_http_client.rb
@@ -5,26 +5,11 @@ class TestHttpClient < MiniTest::Test
     @cm = WebAgent::CookieManager.new
 
     @http = HTTPClient.new
-    @http.cookie_manager = @cm
 
     @logger = Rets::Client::FakeLogger.new
     @logger.stubs(:debug?).returns(false)
 
     @http_client = Rets::HttpClient.new(@http, {}, @logger, "http://rets.rets.com/somestate/login.aspx")
-  end
-
-  def test_http_cookie_with_webagent_cookie
-    cookie1 = "RETS-Session-ID=879392834723043209; path=/; domain=rets.rets.com; expires=Wednesday, 31-Dec-2037 12:00:00 GMT"
-    @cm.parse(cookie1, URI.parse("http://www.rets.rets.com"))
-
-    cookie2 = "Foo=Bar; path=/; domain=rets.rets.com; expires=Wednesday, 31-Dec-2037 12:00:00 GMT"
-    @cm.parse(cookie2, URI.parse("http://www.rets.rets.com"))
-
-    assert_equal "879392834723043209", @http_client.http_cookie('RETS-Session-ID')
-  end
-
-  def test_http_cookie_without_webagent_cookie
-    assert_equal nil, @http_client.http_cookie('RETS-Session-ID')
   end
 
   def test_http_get_delegates_to_client
@@ -45,5 +30,43 @@ class TestHttpClient < MiniTest::Test
     @http.stubs(:post).with(url, anything, anything).returns(response)
 
     assert_equal @http_client.http_post(url, {}), response
+  end
+
+  class CookieManagement < MiniTest::Test
+    def setup
+      @cm = WebAgent::CookieManager.new
+      http = HTTPClient.new
+      http.cookie_manager = @cm
+      @client = Rets::HttpClient.new(http, {}, nil, "http://rets.rets.com/somestate/login.aspx")
+    end
+
+    def teardown
+      # Empty cookie jar
+      @cm.cookies = []
+    end
+
+    def test_http_cookie_with_one_cookie_from_one_domain
+      set_cookie = "RETS-Session-ID=879392834723043209; path=/; domain=rets.rets.com; expires=Wednesday, 31-Dec-2037 12:00:00 GMT"
+      @cm.parse(set_cookie, URI.parse("http://www.rets.rets.com"))
+      assert_equal "879392834723043209", @client.http_cookie('RETS-Session-ID')
+    end
+
+    def test_http_cookie_with_multiple_cookies_from_one_domain
+      # NOTE: Cookies are ordered alphabetically by name when retrieving
+      set_cookie_1 = "RETS-Session-ID=879392834723043209; path=/; domain=rets.rets.com; expires=Wednesday, 31-Dec-2037 12:00:00 GMT"
+      @cm.parse(set_cookie_1, URI.parse("http://www.rets.rets.com"))
+
+      set_cookie_2 = "Zoo=Bar; path=/; domain=rets.rets.com; expires=Wednesday, 31-Dec-2037 12:00:00 GMT"
+      @cm.parse(set_cookie_2, URI.parse("http://www.rets.rets.com"))
+
+      set_cookie_3 = "Foo=Bar; path=/; domain=rets.rets.com; expires=Wednesday, 31-Dec-2037 12:00:00 GMT"
+      @cm.parse(set_cookie_3, URI.parse("http://www.rets.rets.com"))
+
+      assert_equal "879392834723043209", @client.http_cookie('RETS-Session-ID')
+    end
+
+    def test_http_cookie_with_no_cookies_from_domain
+      assert_equal nil, @client.http_cookie('RETS-Session-ID')
+    end
   end
 end


### PR DESCRIPTION
This PR updates the version of the httpclient dependency to `2.6.0`. Due to httpclient's choice to use http-cookie if available instead of the old webagent-cookie implementation, `Rets::HttpClient#http_cookie` implementation needed to change. Httpclient's [changelog](https://github.com/nahi/httpclient/blob/master/CHANGELOG.md#changes-in-260) explains the update. This is why we saw https://github.com/estately/rets/issues/99.

@dougcole @hfaulds I hope this helps with your other PR https://github.com/estately/rets/pull/107

The old Webagent::Cookie responds to `#match?` while `Http::Cookie` (which is what httpclient uses) does not, hence the `undefined method match?` error. This implementation will work with either `Webagent::Cookie` or `Http::Cookie`. 

This implementation uses the CookieManager which is an abstraction layer above the cookie implementation. Whether the CookieManager uses `Http::Cookie` or `Webagent::Cookie`, it will still respond to `#cookie_value`. We can let the user decide whether they would prefer `Http::Cookie` or `Webagent::Cookie`.

I have tested this with both `Webagent::Cookie` and `Http::Cookie` to verify that it works with a real MLS. What do you think about setting up a couple of travis test environments that run with each?