### PR TITLE
add no object found error

### DIFF
--- a/lib/rets.rb
+++ b/lib/rets.rb
@@ -28,6 +28,16 @@ module Rets
     end
   end
 
+  class NoObjectFound < ArgumentError
+    ERROR_CODE = 20403
+    attr_reader :reply_text
+
+    def initialize(reply_text)
+      @reply_text = reply_text
+      super("Got error code #{ERROR_CODE} (#{reply_text})")
+    end
+  end
+
   class InvalidRequest < ArgumentError
     attr_reader :error_code, :reply_text
     def initialize(error_code, reply_text)

--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -383,6 +383,8 @@ module Rets
 
               if reply_code == NoRecordsFound::ERROR_CODE
                 raise NoRecordsFound.new(reply_text)
+              elsif reply_code == NoObjectFound::ERROR_CODE
+                raise NoObjectFound.new(reply_text)
               elsif reply_code.nonzero?
                 raise InvalidRequest.new(reply_code, reply_text)
               else

--- a/test/test_parser_multipart.rb
+++ b/test/test_parser_multipart.rb
@@ -30,7 +30,7 @@ class TestParserMultipart < MiniTest::Test
   end
 
   def test_parse_with_error
-    raw = "\r\n--89467f8e0c6b48158c8f1883910212ec\r\nContent-Type: text/xml\r\nContent-ID: foo\r\nObject-ID: *\r\n\r\n<RETS ReplyCode=\"20403\" ReplyText=\"No Object Found\" />\r\n\r\n--89467f8e0c6b48158c8f1883910212ec--\r\n"
+    raw = "\r\n--89467f8e0c6b48158c8f1883910212ec\r\nContent-Type: text/xml\r\nContent-ID: foo\r\nObject-ID: *\r\n\r\n<RETS ReplyCode=\"999\" ReplyText=\"An Unexplaned Error\" />\r\n\r\n--89467f8e0c6b48158c8f1883910212ec--\r\n"
     boundary = "89467f8e0c6b48158c8f1883910212ec"
     assert_raises Rets::InvalidRequest do
       Rets::Parser::Multipart.parse(raw, boundary)


### PR DESCRIPTION
Some MLSes return this instead when attemting to fetching objects that don't exist.