### PR TITLE
Pull out error checker into a separate file

### DIFF
--- a/lib/rets.rb
+++ b/lib/rets.rb
@@ -59,6 +59,7 @@ end
 
 require 'rets/client'
 require 'rets/metadata'
+require 'rets/parser/error_checker'
 require 'rets/parser/compact'
 require 'rets/parser/multipart'
 require 'rets/measuring_http_client'

--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -61,7 +61,7 @@ module Rets
     # page 34 of http://www.realtor.org/retsorg.nsf/retsproto1.7d6.pdf#page=34
     def login
       res = http_get(login_url)
-      Client::ErrorChecker.check(res)
+      Parser::ErrorChecker.check(res)
 
       self.capabilities = extract_capabilities(Nokogiri.parse(res.body))
       raise UnknownResponse, "Cannot read rets server capabilities." unless @capabilities
@@ -357,52 +357,6 @@ module Rets
     class FakeLogger < Logger
       def initialize
         super(IO::NULL)
-      end
-    end
-
-    class ErrorChecker
-      def self.check(response)
-        # some RETS servers returns HTTP code 412 when session cookie expired, yet the response body
-        # passes XML check. We need to special case for this situation.
-        # This method is also called from multipart.rb where there are headers and body but no status_code
-        if response.respond_to?(:status_code) && response.status_code == 412
-          raise HttpError, "HTTP status: #{response.status_code}, body: #{response.body}"
-        end
-
-        # some RETS servers return success code in XML body but failure code 4xx in http status
-        # If xml body is present we ignore http status
-
-        if !response.body.empty?
-          begin
-            xml = Nokogiri::XML.parse(response.body, nil, nil, Nokogiri::XML::ParseOptions::STRICT)
-
-            rets_element = xml.xpath("/RETS")
-            unless rets_element.empty?
-              reply_text = (rets_element.attr("ReplyText") || rets_element.attr("replyText")).value
-              reply_code = (rets_element.attr("ReplyCode") || rets_element.attr("replyCode")).value.to_i
-
-              if reply_code == NoRecordsFound::ERROR_CODE
-                raise NoRecordsFound.new(reply_text)
-              elsif reply_code == NoObjectFound::ERROR_CODE
-                raise NoObjectFound.new(reply_text)
-              elsif reply_code.nonzero?
-                raise InvalidRequest.new(reply_code, reply_text)
-              else
-                return
-              end
-            end
-          rescue Nokogiri::XML::SyntaxError
-            #Not xml
-          end
-        end
-
-        if response.respond_to?(:ok?) && ! response.ok?
-          if response.status_code == 401
-            raise AuthorizationFailure.new(response.status_code, response.body)
-          else
-            raise HttpError, "HTTP status: #{response.status_code}, body: #{response.body}"
-          end
-        end
       end
     end
   end

--- a/lib/rets/parser/error_checker.rb
+++ b/lib/rets/parser/error_checker.rb
@@ -1,0 +1,49 @@
+module Rets
+  module Parser
+    class ErrorChecker
+      def self.check(response)
+        # some RETS servers returns HTTP code 412 when session cookie expired, yet the response body
+        # passes XML check. We need to special case for this situation.
+        # This method is also called from multipart.rb where there are headers and body but no status_code
+        if response.respond_to?(:status_code) && response.status_code == 412
+          raise HttpError, "HTTP status: #{response.status_code}, body: #{response.body}"
+        end
+
+        # some RETS servers return success code in XML body but failure code 4xx in http status
+        # If xml body is present we ignore http status
+
+        if !response.body.empty?
+          begin
+            xml = Nokogiri::XML.parse(response.body, nil, nil, Nokogiri::XML::ParseOptions::STRICT)
+
+            rets_element = xml.xpath("/RETS")
+            unless rets_element.empty?
+              reply_text = (rets_element.attr("ReplyText") || rets_element.attr("replyText")).value
+              reply_code = (rets_element.attr("ReplyCode") || rets_element.attr("replyCode")).value.to_i
+
+              if reply_code == NoRecordsFound::ERROR_CODE
+                raise NoRecordsFound.new(reply_text)
+              elsif reply_code == NoObjectFound::ERROR_CODE
+                raise NoObjectFound.new(reply_text)
+              elsif reply_code.nonzero?
+                raise InvalidRequest.new(reply_code, reply_text)
+              else
+                return
+              end
+            end
+          rescue Nokogiri::XML::SyntaxError
+            #Not xml
+          end
+        end
+
+        if response.respond_to?(:ok?) && ! response.ok?
+          if response.status_code == 401
+            raise AuthorizationFailure.new(response.status_code, response.body)
+          else
+            raise HttpError, "HTTP status: #{response.status_code}, body: #{response.body}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rets/parser/multipart.rb
+++ b/lib/rets/parser/multipart.rb
@@ -1,6 +1,5 @@
 module Rets
   module Parser
-
     # Inspired by Mail.
     class Multipart
       CRLF = "\r\n"
@@ -33,7 +32,7 @@ module Rets
 
       def self.check_for_invalids_parts!(parts)
         return unless parts.length == 1 && parts.first.headers['content-type'] == 'text/xml'
-        Client::ErrorChecker.check(parts.first)
+        ErrorChecker.check(parts.first)
       end
     end
   end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1,4 +1,16 @@
-RETS_ERROR = <<-XML
+RETS_NO_RECORDS_ERROR = <<-XML
+<?xml version="1.0"?>
+<RETS ReplyCode="20201" ReplyText="Error message">
+</RETS>
+XML
+
+RETS_NO_OBJECT_ERROR = <<-XML
+<?xml version="1.0"?>
+<RETS ReplyCode="20403" ReplyText="Error message">
+</RETS>
+XML
+
+RETS_INVALID_REQUEST_ERROR = <<-XML
 <?xml version="1.0"?>
 <RETS ReplyCode="123" ReplyText="Error message">
 </RETS>

--- a/test/test_error_checker.rb
+++ b/test/test_error_checker.rb
@@ -1,13 +1,12 @@
 require_relative "helper"
 
 class TestErrorChecker < MiniTest::Test
-
   def test_check_with_status_code_412
     response = mock
     response.stubs(:status_code).returns(412)
     response.stubs(:body).returns('junk')
     assert_raises Rets::HttpError do
-      Rets::Client::ErrorChecker.check(response)
+      Rets::Parser::ErrorChecker.check(response)
     end
   end
 
@@ -18,7 +17,7 @@ class TestErrorChecker < MiniTest::Test
     response.stubs(:ok?).returns(false)
     response.stubs(:body).returns('')
     assert_raises Rets::AuthorizationFailure do
-      Rets::Client::ErrorChecker.check(response)
+      Rets::Parser::ErrorChecker.check(response)
     end
   end
 
@@ -29,7 +28,7 @@ class TestErrorChecker < MiniTest::Test
     response.stubs(:ok?).returns(false)
     response.stubs(:body).returns(HTML_AUTH_FAILURE)
     assert_raises Rets::AuthorizationFailure do
-      Rets::Client::ErrorChecker.check(response)
+      Rets::Parser::ErrorChecker.check(response)
     end
   end
 
@@ -40,8 +39,7 @@ class TestErrorChecker < MiniTest::Test
     response.stubs(:ok?).returns(false)
     response.stubs(:body).returns(XHTML_AUTH_FAILURE)
     assert_raises Rets::AuthorizationFailure do
-      Rets::Client::ErrorChecker.check(response)
+      Rets::Parser::ErrorChecker.check(response)
     end
   end
-
 end

--- a/test/test_error_checker.rb
+++ b/test/test_error_checker.rb
@@ -42,4 +42,28 @@ class TestErrorChecker < MiniTest::Test
       Rets::Parser::ErrorChecker.check(response)
     end
   end
+
+  def test_no_records_found_failure
+    response = mock
+    response.stubs(:body).returns(RETS_NO_RECORDS_ERROR)
+    assert_raises Rets::NoRecordsFound do
+      Rets::Parser::ErrorChecker.check(response)
+    end
+  end
+
+  def test_no_object_found_failure
+    response = mock
+    response.stubs(:body).returns(RETS_NO_OBJECT_ERROR)
+    assert_raises Rets::NoObjectFound do
+      Rets::Parser::ErrorChecker.check(response)
+    end
+  end
+
+  def test_invalid_request_failure
+    response = mock
+    response.stubs(:body).returns(RETS_INVALID_REQUEST_ERROR)
+    assert_raises Rets::InvalidRequest do
+      Rets::Parser::ErrorChecker.check(response)
+    end
+  end
 end


### PR DESCRIPTION
Spurred on by https://github.com/estately/rets/pull/115#discussion_r31151209

Added some extra tests to capture all the RETS errors we raise.