### PR TITLE
Migrate Client::ErrorChecker to Parser::ErrorChecker in http_client

### DIFF
--- a/lib/rets/http_client.rb
+++ b/lib/rets/http_client.rb
@@ -17,7 +17,7 @@ module Rets
       log_http_traffic("GET", url, params, headers) do
         res = http.get(url, params, headers)
       end
-      Client::ErrorChecker.check(res)
+      Parser::ErrorChecker.check(res)
       res
     end
 
@@ -28,7 +28,7 @@ module Rets
       log_http_traffic("POST", url, params, headers) do
         res = http.post(url, params, headers)
       end
-      Client::ErrorChecker.check(res)
+      Parser::ErrorChecker.check(res)
       res
     end
 


### PR DESCRIPTION
I was getting an error after https://github.com/estately/rets/pull/117 was merged because HttpClient was still referencing the old ErrorChecker. 