### PR TITLE
upgrade httpclient and include http-cookie

### DIFF
--- a/lib/rets.rb
+++ b/lib/rets.rb
@@ -57,6 +57,7 @@ module Rets
   end
 end
 
+require 'rets/cookie_manager'
 require 'rets/http_client'
 require 'rets/client'
 require 'rets/metadata'

--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -1,4 +1,3 @@
-require 'httpclient'
 require 'logger'
 
 module Rets
@@ -44,7 +43,7 @@ module Rets
         @http.receive_timeout = @options[:receive_timeout]
       end
 
-      @http.set_cookie_store(options[:cookie_store]) if options[:cookie_store]
+      @http.cookie_manager = Rets::CookieManager.new(options[:cookie_store])
 
       @http_client = Rets::HttpClient.new(@http, @options, @logger, @login_url)
       if options[:http_timing_stats_collector]

--- a/lib/rets/cookie_manager.rb
+++ b/lib/rets/cookie_manager.rb
@@ -8,6 +8,7 @@ module Rets
     def initialize(cookies_file = nil, format = HTTPClient::WebAgentSaver, jar = HTTP::CookieJar.new)
       super(cookies_file, format)
       @jar = jar
+      load_cookies if @cookies_file
     end
   end
 end

--- a/lib/rets/cookie_manager.rb
+++ b/lib/rets/cookie_manager.rb
@@ -1,0 +1,13 @@
+require 'httpclient'
+require 'http-cookie'
+
+module Rets
+  class CookieManager < WebAgent::CookieManager
+    attr_reader :jar
+
+    def initialize(cookies_file = nil, format = HTTPClient::WebAgentSaver, jar = HTTP::CookieJar.new)
+      super(cookies_file, format)
+      @jar = jar
+    end
+  end
+end

--- a/lib/rets/http_client.rb
+++ b/lib/rets/http_client.rb
@@ -82,8 +82,10 @@ module Rets
     end
 
     def http_cookie(name)
-      http.cookies.each do |c|
-        return c.value if c.name.downcase == name.downcase && c.match?(URI.parse(login_url))
+      @http.cookie_manager.instance_variable_get(:@jar).each(login_url) do |c|
+        if c.name.downcase == name.downcase
+          return c.value
+        end
       end
       nil
     end

--- a/lib/rets/http_client.rb
+++ b/lib/rets/http_client.rb
@@ -82,7 +82,7 @@ module Rets
     end
 
     def http_cookie(name)
-      @http.cookie_manager.instance_variable_get(:@jar).each(login_url) do |c|
+      @http.cookie_manager.jar.each(login_url) do |c|
         if c.name.downcase == name.downcase
           return c.value
         end

--- a/rets.gemspec
+++ b/rets.gemspec
@@ -25,7 +25,8 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httpclient>, ["~> 2.4"])
+      s.add_runtime_dependency(%q<http-cookie>, ["~> 1.0"])
+      s.add_runtime_dependency(%q<httpclient>, ["~> 2.6"])
       s.add_runtime_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<mocha>, ["~> 0.11"])
@@ -33,7 +34,8 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<webmock>, ["~> 1.8"])
       s.add_development_dependency(%q<hoe>, ["~> 3.6"])
     else
-      s.add_dependency(%q<httpclient>, ["~> 2.4"])
+      s.add_dependency(%q<http-cookie>, ["~> 1.0"])
+      s.add_dependency(%q<httpclient>, ["~> 2.6"])
       s.add_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<mocha>, ["~> 0.11"])
@@ -42,7 +44,8 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<hoe>, ["~> 3.6"])
     end
   else
-    s.add_dependency(%q<httpclient>, ["~> 2.4"])
+    s.add_dependency(%q<http-cookie>, ["~> 1.0"])
+    s.add_dependency(%q<httpclient>, ["~> 2.6"])
     s.add_dependency(%q<nokogiri>, ["~> 1.5"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<mocha>, ["~> 0.11"])

--- a/test/test_http_client.rb
+++ b/test/test_http_client.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 class TestHttpClient < MiniTest::Test
   def setup
-    @cm = WebAgent::CookieManager.new
+    @cm = Rets::CookieManager.new
 
     @http = HTTPClient.new
     @http.cookie_manager = @cm


### PR DESCRIPTION
We discussed this in https://github.com/estately/rets/pull/113 and https://github.com/estately/rets/issues/105

To summarise. At the moment our `Rets::HttpClient#http_cookie` implementation assumes the `httpclient` is using `WebAgent::CookieManager` and `WebAgent::Cookie` under the hood.

If a project requires `httpclient` 2.6 and `http-cookie` then this breaks as `httpclient` loads `HttpClient::CookieManager` and a different cookie implementation.

A couple quick fixes would be to:
- explicitly require 'httpclient/webagent-cookie' in our `Rets::HttpClient`
- explicitly depend on `http-cookie` and change out `Rets::HttpClient#http_cookie`

Moving away from `WebAgent::CookieManager` is a step towards being able to store cookies in storage other than the filesystem (https://github.com/estately/rets/issues/105). It is more up to date with RFC and more flexible as well.

`Rets::CookieManager` exists to expose `jar` publicly. I made a PR to httpclient so that in the future we should be able to avoid this: https://github.com/nahi/httpclient/pull/254.

This will also make it easy to provide a custom cookie jar implementation.
