### PR TITLE
Fixed passing of gem-specific options into RETS requests

### DIFF
--- a/lib/rets/client_progress_reporter.rb
+++ b/lib/rets/client_progress_reporter.rb
@@ -18,10 +18,10 @@ module Rets
       @stats_prefix = stats_prefix
     end
 
-    def find_with_retries_failed_a_retry(exception, retries)
+    def find_with_retries_failed_a_retry(exception, max_retries)
       @stats.count("#{@stats_prefix}find_with_retries_failed_retry")
       @logger.warn("Rets::Client: Failed with message: #{exception.message}")
-      @logger.info("Rets::Client: Retry #{retries}/3")
+      @logger.info("Rets::Client: Retries left #{max_retries}")
     end
 
     def find_with_retries_exceeded_retry_count(exception)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -288,4 +288,17 @@ class TestClient < MiniTest::Test
     )
   end
 
+  def test_find_do_not_pass_gem_specific_options_into_http_request
+    @client.stubs(:capability_url).with('Search').returns('search_url')
+    response = mock
+    response.stubs(:body).returns('Some response')
+
+    @client.stubs(:http_post).with do |_, query|
+      internal_options = %w(NoRecordsNotAnError MaxRetries Resolve) & query.keys
+      internal_options.empty?
+    end.returns(response)
+
+    @client.find :all, no_records_not_an_error: true, max_retries: 4, resolve: false
+  end
+
 end


### PR DESCRIPTION
I found that body of requests contains `NoRecordsNotAnError=true` when I use search with the `no_records_not_an_error: true` option.