### PR TITLE
Clean up client constructor and how we use attr_reader/writer

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -1,5 +1,3 @@
-require 'http-cookie'
-require 'httpclient'
 require 'logger'
 
 module Rets

--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -16,13 +16,13 @@ module Rets
     end
 
     def clean_setup
-      @capabilities    = nil
       @metadata        = nil
       @tries           = nil
       @login_url       = options[:login_url]
+      @cached_metadata = options[:metadata]
+      @capabilities    = options[:capabilities]
       @logger          = options[:logger] || FakeLogger.new
       @client_progress = ClientProgressReporter.new(logger, options[:stats_collector], options[:stats_prefix])
-      @cached_metadata = options[:metadata]
       @http_client     = Rets::HttpClient.from_options(options, logger)
     end
 

--- a/lib/rets/http_client.rb
+++ b/lib/rets/http_client.rb
@@ -24,6 +24,7 @@ module Rets
       if options[:receive_timeout]
         http.receive_timeout = options[:receive_timeout]
       end
+
       if options[:cookie_store]
         http.set_cookie_store(options[:cookie_store])
       end
@@ -33,9 +34,11 @@ module Rets
       if options[:http_timing_stats_collector]
         http_client = Rets::MeasuringHttpClient.new(http_client, options.fetch(:http_timing_stats_collector), options.fetch(:http_timing_stats_prefix))
       end
+
       if options[:lock_around_http_requests]
         http_client = Rets::LockingHttpClient.new(http_client, options.fetch(:locker), options.fetch(:lock_name), options.fetch(:lock_options))
       end
+
       http_client
     end
 

--- a/lib/rets/http_client.rb
+++ b/lib/rets/http_client.rb
@@ -10,6 +10,35 @@ module Rets
       @options.fetch(:ca_certs, []).each {|c| @http.ssl_config.add_trust_ca(c) }
     end
 
+    def self.from_options(options, logger)
+      if options[:http_proxy]
+        http = HTTPClient.new(options.fetch(:http_proxy))
+
+        if options[:proxy_username]
+          http.set_proxy_auth(options.fetch(:proxy_username), options.fetch(:proxy_password))
+        end
+      else
+        http = HTTPClient.new
+      end
+
+      if options[:receive_timeout]
+        http.receive_timeout = options[:receive_timeout]
+      end
+      if options[:cookie_store]
+        http.set_cookie_store(options[:cookie_store])
+      end
+
+      http_client = new(http, options, logger, options[:login_url])
+
+      if options[:http_timing_stats_collector]
+        http_client = Rets::MeasuringHttpClient.new(http_client, options.fetch(:http_timing_stats_collector), options.fetch(:http_timing_stats_prefix))
+      end
+      if options[:lock_around_http_requests]
+        http_client = Rets::LockingHttpClient.new(http_client, options.fetch(:locker), options.fetch(:lock_name), options.fetch(:lock_options))
+      end
+      http_client
+    end
+
     def http_get(url, params=nil, extra_headers={})
       http.set_auth(url, options[:username], options[:password])
       headers = extra_headers.merge(rets_extra_headers)

--- a/lib/rets/http_client.rb
+++ b/lib/rets/http_client.rb
@@ -1,3 +1,6 @@
+require 'http-cookie'
+require 'httpclient'
+
 module Rets
   class HttpClient
     attr_reader :http, :options, :logger, :login_url

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -21,9 +21,9 @@ class TestClient < MiniTest::Test
   end
 
   def test_capability_url_returns_parsed_url
-    @client.capabilities = { "foo" => "/foo" }
+    client = Rets::Client.new(:login_url => "http://example.com", :capabilities => { "foo" => "/foo" })
 
-    assert_equal "http://example.com/foo", @client.capability_url("foo")
+    assert_equal "http://example.com/foo", client.capability_url("foo")
   end
 
   def test_capabilities_calls_login_when_nil

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -249,14 +249,6 @@ class TestClient < MiniTest::Test
     assert_equal "foo", @client.object("1", :foo => :bar)
   end
 
-  def test_metadata_caches
-    metadata = stub(:current? => true)
-    @client.metadata = metadata
-    @client.stubs(:capabilities => {})
-
-    assert_same metadata, @client.metadata, "Should be memoized"
-  end
-
   def test_decorate_result_handles_bad_metadata
     result = {'foo' => 'bar'}
     rets_class = stub


### PR DESCRIPTION
It's been bugging me that we have such a confusing constructor.

Some of it got moved to `Rets::HttpClient`

I tried to clean up where we refer to instance variables with attr_readers within the class (sometimes we would refer to them as `self.foo`,`@foo` or `foo`).

I removed the attr_writer and allowed those arguments to be passed into the constructor.

The only instance var I left that confuses me is `@tries` which appears to be some now-defunct code which I would be in favour of deleting.