### PR TITLE
fix cookie saving with http-cookie

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -336,8 +336,8 @@ module Rets
       hash
     end
 
-    def save_cookie_store(force=nil)
-      @http_client.save_cookie_store(force)
+    def save_cookie_store
+      @http_client.save_cookie_store
     end
 
     def http_get(url, params=nil, extra_headers={})

--- a/lib/rets/http_client.rb
+++ b/lib/rets/http_client.rb
@@ -52,13 +52,10 @@ module Rets
       end
     end
 
-    def save_cookie_store(force=nil)
+    def save_cookie_store
       if options[:cookie_store]
-        if force
-          @http.cookie_manager.save_all_cookies(true, true, true)
-        else
-          @http.save_cookie_store
-        end
+        #save session cookies
+        @http.cookie_manager.save_cookies(true)
       end
     end
 

--- a/lib/rets/locking_http_client.rb
+++ b/lib/rets/locking_http_client.rb
@@ -19,8 +19,8 @@ module Rets
       end
     end
 
-    def save_cookie_store(force=nil)
-      @http_client.save_cookie_store(force)
+    def save_cookie_store
+      @http_client.save_cookie_store
     end
 
     def lock_around(&block)

--- a/lib/rets/measuring_http_client.rb
+++ b/lib/rets/measuring_http_client.rb
@@ -20,8 +20,8 @@ module Rets
       end
     end
 
-    def save_cookie_store(force=nil)
-      @http_client.save_cookie_store(force)
+    def save_cookie_store
+      @http_client.save_cookie_store
     end
   end
 end

--- a/test/test_http_client.rb
+++ b/test/test_http_client.rb
@@ -68,5 +68,29 @@ class TestHttpClient < MiniTest::Test
     def test_http_cookie_with_no_cookies_from_domain
       assert_equal nil, @client.http_cookie('RETS-Session-ID')
     end
+
+    def test_save_cookie_store
+      cookie_file = Tempfile.new('cookie_file').path
+
+      #setup cookie store
+      http_a = HTTPClient.new
+      http_a.set_cookie_store(cookie_file)
+      client_a = Rets::HttpClient.new(http_a, { cookie_store: cookie_file }, nil, "http://rets.rets.com/somestate/login.aspx")
+
+      #add cookie
+      cookie = "RETS-Session-ID=879392834723043209; path=/; domain=rets.rets.com; expires=Wednesday, 31-Dec-2037 12:00:00 GMT"
+      http_a.cookie_manager.parse(cookie, URI.parse("http://www.rets.rets.com"))
+
+      #save cookie
+      client_a.save_cookie_store
+
+      #create new HTTPCLient with same cookie store
+      http_b = HTTPClient.new
+      http_b.set_cookie_store(cookie_file)
+      client_b = Rets::HttpClient.new(http_b, { cookie_store: cookie_file }, nil, "http://rets.rets.com/somestate/login.aspx")
+
+      #check added cookie exists
+      assert_equal "879392834723043209", client_b.http_cookie('RETS-Session-ID')
+    end
   end
 end


### PR DESCRIPTION
Previously we called either `HTTPClient.save_cookie_store` or `Webagent::CookieManager.save_all_cookies`

HTTPClient:
```
def save_cookie_store
  @cookie_manager.save_cookies
end
```
https://github.com/nahi/httpclient/blob/b986cec52df1f2d6610a469f13f3778e81ba9dfa/lib/httpclient.rb#L580

Webagent::CookieManager
`def save_all_cookies(force = nil, save_unused = true, save_discarded = true)`
https://github.com/nahi/httpclient/blob/master/lib/httpclient/webagent-cookie.rb

Unfortunately `save_all_cookies` does not exist on HTTPClient::CookieManager (which we use because we include the `http-cookie` gem)

HTTPClient::CookieManager
`def save_cookies(session = false)`
https://github.com/nahi/httpclient/blob/master/lib/httpclient/cookie.rb#L25

There is no concept of `force` here but there is the option to save session cookies. To keep some kind of backward compatibility (and because estately want them) we will save session cookies. This can easily be put behind an option but there is no point adding one until some-one says they want it.