### PR TITLE
ensure cookie store exists

### DIFF
--- a/lib/rets/http_client.rb
+++ b/lib/rets/http_client.rb
@@ -29,6 +29,7 @@ module Rets
       end
 
       if options[:cookie_store]
+        ensure_cookie_store_exists! options[:cookie_store]
         http.set_cookie_store(options[:cookie_store])
       end
 
@@ -43,6 +44,12 @@ module Rets
       end
 
       http_client
+    end
+
+    def self.ensure_cookie_store_exists!(cookie_store)
+      unless File.exist? cookie_store
+        FileUtils.touch(cookie_store)
+      end
     end
 
     def http_get(url, params=nil, extra_headers={})


### PR DESCRIPTION
Noticed loading from a non-existant cookie store caused an exception (previous to using `http-cookie` it was possible).

I assumed saving would exception as well if the file was removed after initialization but before saving. It appears I was incorrect but I think the test is useful anyway.