### PR TITLE
make cached capabilities case insensitive

### DIFF
--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -26,6 +26,12 @@ class TestClient < MiniTest::Test
     assert_equal "http://example.com/foo", client.capability_url("foo")
   end
 
+  def test_cached_capabilities_case_insensitive
+    client = Rets::Client.new(:login_url => "http://example.com", :capabilities => { "foo" => "/foo" })
+
+    assert_equal client.capabilities.default_proc, Rets::Client::CASE_INSENSITIVE_PROC
+  end
+
   def test_capabilities_calls_login_when_nil
     @client.expects(:login)
     @client.capabilities


### PR DESCRIPTION
I noticed whilst cached capabilities that there was a default proc on the capabilities hash.

If we're going to accept cached capabilities we should probably make their keys case insensitive as well.