### PR TITLE
Whitelist search options

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -112,9 +112,12 @@ module Rets
     end
 
     def find_every(opts)
+      raise ArgumentError.new("missing option :search_type (provide the name of a RETS resource)") unless opts[:search_type]
+      raise ArgumentError.new("missing option :class (provide the name of a RETS class)") unless opts[:class]
+
       params = {
-        "SearchType"          => opts[:search_type],
-        "Class"               => opts[:class],
+        "SearchType"          => opts.fetch(:search_type),
+        "Class"               => opts.fetch(:class),
 
         "Count"               => opts[:count],
         "Format"              => opts.fetch(:format, "COMPACT"),

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -88,6 +88,18 @@ class TestClient < MiniTest::Test
   end
 
   def test_find_first_calls_find_every_with_limit_one
+    assert_raises ArgumentError do
+      @client.find_every({})
+    end
+    assert_raises ArgumentError do
+      @client.find_every(:search_type => "Foo")
+    end
+    assert_raises ArgumentError do
+      @client.find_every(:class => "Bar")
+    end
+  end
+
+  def test_find_first_calls_find_every_with_limit_one
     @client.expects(:find_every).with({:limit => 1, :foo => :bar}, nil).returns([1,2,3])
 
     assert_equal 1, @client.find(:first, :foo => :bar, :limit => 5), "User-specified limit should be ignored"
@@ -114,7 +126,7 @@ class TestClient < MiniTest::Test
 
     Rets::Parser::Compact.expects(:parse_document).with("An ascii string")
 
-    @client.find_every({})
+    @client.find_every(:search_type => "Foo", :class => "Bar")
   end
 
   def test_response_text_encoding_from_utf_8
@@ -126,7 +138,7 @@ class TestClient < MiniTest::Test
 
     Rets::Parser::Compact.expects(:parse_document).with("Some string with non-ascii characters \u0119")
 
-    @client.find_every({})
+    @client.find_every(:search_type => "Foo", :class => "Bar")
   end
 
   def test_response_text_encoding_from_utf_16
@@ -138,7 +150,7 @@ class TestClient < MiniTest::Test
 
     Rets::Parser::Compact.expects(:parse_document).with("Some string with non-utf-8 characters \uFFFD")
 
-    @client.find_every({})
+    @client.find_every(:search_type => "Foo", :class => "Bar")
   end
 
   def test_find_retries_when_receiving_no_records_found

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -114,7 +114,7 @@ class TestClient < MiniTest::Test
 
     Rets::Parser::Compact.expects(:parse_document).with("An ascii string")
 
-    @client.find_every({}, false)
+    @client.find_every({})
   end
 
   def test_response_text_encoding_from_utf_8
@@ -126,7 +126,7 @@ class TestClient < MiniTest::Test
 
     Rets::Parser::Compact.expects(:parse_document).with("Some string with non-ascii characters \u0119")
 
-    @client.find_every({}, false)
+    @client.find_every({})
   end
 
   def test_response_text_encoding_from_utf_16
@@ -138,7 +138,7 @@ class TestClient < MiniTest::Test
 
     Rets::Parser::Compact.expects(:parse_document).with("Some string with non-utf-8 characters \uFFFD")
 
-    @client.find_every({}, false)
+    @client.find_every({})
   end
 
   def test_find_retries_when_receiving_no_records_found
@@ -164,21 +164,12 @@ class TestClient < MiniTest::Test
     @client.find(:all, :foo => :bar)
   end
 
-  def test_find_retries_on_errors_preserves_resolve
-    @client.stubs(:find_every).raises(Rets::AuthorizationFailure.new(401, 'Not Authorized')).then.raises(Rets::InvalidRequest.new(20134, 'Not Found')).then.with({:foo => :bar}, true).returns([])
-    @client.find(:all, {:foo => :bar, :resolve => true})
-  end
-
   def test_find_eventually_reraises_errors
     @client.stubs(:find_every).raises(Rets::AuthorizationFailure.new(401, 'Not Authorized'))
+
     assert_raises Rets::AuthorizationFailure do
       @client.find(:all, :foo => :bar)
     end
-  end
-
-  def test_fixup_keys
-    assert_equal({ "Foo" => "bar" },    @client.fixup_keys(:foo => "bar"))
-    assert_equal({ "FooFoo" => "bar" }, @client.fixup_keys(:foo_foo => "bar"))
   end
 
   def test_all_objects_calls_objects


### PR DESCRIPTION
For https://github.com/estately/rets/pull/124

Prevents us from passing non-rets options to a server.

Simplifies the logic we have around our gem-specific resolve option.