### PR TITLE
Dont send unset params

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -130,7 +130,7 @@ module Rets
         "Payload"             => opts[:payload],
         "Query"               => opts[:query],
         "QueryType"           => opts.fetch(:query_type, "DMQL2"),
-      }
+      }.reject { |k,v| v.nil? }
       res = http_post(capability_url("Search"), params)
 
       if opts[:count] == COUNT.only


### PR DESCRIPTION
https://github.com/estately/rets/pull/142 meant we were now sending blank params to RETS servers.

A whole bunch of the mlses we integrate with did not like that (we were seeing a message along the lines of `unknown value for StandardNames`).

We could add sane defaults but I prefer to leave that to their RETS server.
Especially as I'm also a tad nervous that some options might have been added in later versions of RETS (although haven't looked through the different specs to confirm).

This is pulled out of https://github.com/estately/rets/pull/98 as that's what we're testing in production at the moment.