### PR TITLE
Fixed call of login internally when it already was called

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -37,7 +37,7 @@ module Rets
       unless new_capabilities
         raise UnknownResponse, "Cannot read rets server capabilities."
       end
-      new_capabilities
+      @capabilities = new_capabilities
     end
 
     def logout
@@ -283,7 +283,7 @@ module Rets
       elsif @cached_capabilities
         @capabilities = add_case_insensitive_default_proc(@cached_capabilities)
       else
-        @capabilities = login
+        login
       end
     end
 

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -37,6 +37,16 @@ class TestClient < MiniTest::Test
     @client.capabilities
   end
 
+  def test_capabilities_does_not_call_login_after_login
+    response = mock
+    response.stubs(:body).returns(CAPABILITIES)
+    @client.stubs(:http_get).returns(response)
+    @client.login
+
+    @client.expects(:login).never
+    @client.capabilities
+  end
+
   def test_tries_increments_with_each_call
     assert_equal 1, @client.tries
     assert_equal 2, @client.tries


### PR DESCRIPTION
Noticed that call of `#login` method doesn't save received capabilities.
This caused that all our sessions begins with 2 requests for `:login_url` (first by our call for `#login` and second by internal call for `#login`). This PR should fix that.