### PR TITLE
return non-looked-up-values in resolve

### DIFF
--- a/lib/rets/metadata/lookup_table.rb
+++ b/lib/rets/metadata/lookup_table.rb
@@ -61,7 +61,7 @@ module Rets
 
           lookup_type = lookup_type(clean_value)
 
-          resolved_value = lookup_type ? lookup_type.long_value : nil
+          resolved_value = lookup_type ? lookup_type.long_value : clean_value
 
           warn("Discarding unmappable value of #{clean_value.inspect}") if resolved_value.nil? && $VERBOSE
 


### PR DESCRIPTION
We've had some problem mlses where we had to use the `COMPACT-DECODED` format (which is significantly slower to fetch) because when using `COMPACT` and 'resolving' the values using the metadata we had fields with missing values.

I've tried multiple times to see if I could get thngs working using `COMPACT`.

This fix appears to work though.

For a single property I fetched 3 times, once with compact_decoded, once with compact and once with this new change:

```
DEVELOPMENT [90] pry(main)> compact_decoded_data.select { |k,v| v != compact_data[k] }
{
  "County" => "S",
  "Lsc" => "EXT",
  "Ste" => "NY",
  "Temp_off_mkt" => "N"
}
DEVELOPMENT [91] pry(main)> compact_decoded_data.select { |k,v| v != new_compact_data[k] }
{
  "County" => "S"
}
DEVELOPMENT [92] pry(main)> new_compact_data["County"]
"Suffolk"
DEVELOPMENT [93] pry(main)> compact_decoded_data["County"]
"S"
```