### PR TITLE
Fixes inversed 'no records found' behaviour

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -90,10 +90,10 @@ module Rets
         find_every(opts)
       rescue NoRecordsFound => e
         if opts.fetch(:no_records_not_an_error, false)
+          handle_find_failure(retries, opts, e)
+        else
           client_progress.no_records_found
           opts[:count] == COUNT.only ? 0 : []
-        else
-          handle_find_failure(retries, opts, e)
         end
       rescue AuthorizationFailure, InvalidRequest => e
         handle_find_failure(retries, opts, e)


### PR DESCRIPTION
We noticed the behaviour in the gem was the opposite of what expected. This commit fixes the issue.
(Thanks to @imstevecho for looking into it also)