### PR TITLE
retry http errors

### DIFF
--- a/lib/rets.rb
+++ b/lib/rets.rb
@@ -5,6 +5,7 @@ require 'nokogiri'
 module Rets
   VERSION = '0.9.0'
 
+  HttpError            = Class.new(StandardError)
   MalformedResponse    = Class.new(ArgumentError)
   UnknownResponse      = Class.new(ArgumentError)
   NoLogout             = Class.new(ArgumentError)

--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -1,8 +1,6 @@
 require 'logger'
 
 module Rets
-  class HttpError < StandardError ; end
-
   class Client
     COUNT = Struct.new(:exclude, :include, :only).new(0,1,2)
     CASE_INSENSITIVE_PROC = Proc.new { |h,k| h.key?(k.downcase) ? h[k.downcase] : nil }
@@ -95,7 +93,7 @@ module Rets
         else
           handle_find_failure(retries, opts, e)
         end
-      rescue AuthorizationFailure, InvalidRequest => e
+      rescue AuthorizationFailure, InvalidRequest, HttpError => e
         handle_find_failure(retries, opts, e)
       end
     end


### PR DESCRIPTION
I don't see any reason not to retry http errors. We have an mls where we fetch keys in batches and occasionally hit a timeout error and need to retry rather than fetching all again.