### PR TITLE
Revert "Fixes inversed 'no records found' behaviour"

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -90,10 +90,10 @@ module Rets
         find_every(opts)
       rescue NoRecordsFound => e
         if opts.fetch(:no_records_not_an_error, false)
-          handle_find_failure(retries, opts, e)
-        else
           client_progress.no_records_found
           opts[:count] == COUNT.only ? 0 : []
+        else
+          handle_find_failure(retries, opts, e)
         end
       rescue AuthorizationFailure, InvalidRequest => e
         handle_find_failure(retries, opts, e)


### PR DESCRIPTION
Reverts estately/rets#152

This is failing a bunch of tests. Sorry @ivar

Reading through the tests. Upon receiving `NoRecordsFound`:
- If `no_records_not_an_error` is truthy then we don't retry or raise an exception and return 0 or [] (depending if the query is a count query)
- if `no_records_not_an_error` is falsey (default) then we retry and eventually raise an exception after X retries