### PR TITLE
Rets::Parser::Compact.get_count always returns a number.

### DIFF
--- a/lib/rets/parser/compact.rb
+++ b/lib/rets/parser/compact.rb
@@ -87,10 +87,9 @@ module Rets
       def self.get_count(xml)
         doc = Nokogiri.parse(xml.to_s)
         if node = doc.at("//COUNT")
-          return node.attr('Records').to_i
-        elsif node = doc.at("//RETS-STATUS")
-          # Handle <RETS-STATUS ReplyCode="20201" ReplyText="No matching records were found" />
-          return 0 if node.attr('ReplyCode') == '20201'
+          node.attr('Records').to_i
+        else
+          0
         end
       end
 

--- a/test/test_parser_compact.rb
+++ b/test/test_parser_compact.rb
@@ -51,6 +51,11 @@ class TestParserCompact < MiniTest::Test
     assert_equal 0, count
   end
 
+  def test_get_count_with_unrecognized_document
+    count = Rets::Parser::Compact.get_count("")
+    assert_equal 0, count
+  end
+
   def test_parse_example
     rows = Rets::Parser::Compact.parse_document(SAMPLE_COMPACT)
 


### PR DESCRIPTION
Previously this method either returned a Fixnum or nil. Now it always returns a Fixnum.