### PR TITLE
lookup tables case insensitively

### DIFF
--- a/lib/rets/metadata/rets_class.rb
+++ b/lib/rets/metadata/rets_class.rb
@@ -50,7 +50,7 @@ module Rets
       end
 
       def find_table(name)
-        tables.detect { |value| value.name == name }
+        tables.detect { |value| value.name.downcase == name.downcase }
       end
     end
   end


### PR DESCRIPTION
Whilst adding solds for one MLS we noticed the data coming back didn't match the case of the same fields in the metadata.

The only way this could be a problem is if an mls has two tables with different casing which seems very unlikely.