### PR TITLE
Update httpclient to ~>2.7.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ Hoe.plugin :gemspec
 Hoe.spec 'rets' do
   developer 'Estately, Inc. Open Source', 'opensource@estately.com'
 
-  extra_deps << [ "httpclient", "~> 2.6.0" ]
+  extra_deps << [ "httpclient", "~> 2.7.0" ]
   extra_deps << [ "http-cookie", "~> 1.0.0" ]
   extra_deps << [ "nokogiri",   "~> 1.5" ]
 

--- a/rets.gemspec
+++ b/rets.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httpclient>, ["~> 2.6.0"])
+      s.add_runtime_dependency(%q<httpclient>, ["~> 2.7.0"])
       s.add_runtime_dependency(%q<http-cookie>, ["~> 1.0.0"])
       s.add_runtime_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<webmock>, ["~> 1.8"])
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
     else
-      s.add_dependency(%q<httpclient>, ["~> 2.6.0"])
+      s.add_dependency(%q<httpclient>, ["~> 2.7.0"])
       s.add_dependency(%q<http-cookie>, ["~> 1.0.0"])
       s.add_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<hoe>, ["~> 3.13"])
     end
   else
-    s.add_dependency(%q<httpclient>, ["~> 2.6.0"])
+    s.add_dependency(%q<httpclient>, ["~> 2.7.0"])
     s.add_dependency(%q<http-cookie>, ["~> 1.0.0"])
     s.add_dependency(%q<nokogiri>, ["~> 1.5"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])


### PR DESCRIPTION
This will get rid of the crazy amount of warnings in the logs from httpclient :tada: 
`Cookie#domain returns dot-less domain name now. Use Cookie#dot_domain if you need "." at the beginning.`

This warning will show up only [once](https://github.com/nahi/httpclient/blob/master/lib/httpclient/cookie.rb#L210). I've run this against a couple RETS servers. Everything seems to be working fine.