### PR TITLE
getObject fails if the returned object is the http body not http multiparts

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -203,10 +203,11 @@ module Rets
 
         return parts
       else
+        logger.debug "Rets::Client: Found 1 part (the whole body)"
+
         # fake a multipart for interface compatibility
         headers = {}
-        response.headers.each { |k,v| headers[k] = v[0] }
-
+        response.headers.each { |k,v| headers[k.downcase] = v }
         part = Parser::Multipart::Part.new(headers, response.body)
 
         return [part]

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -256,7 +256,7 @@ class TestClient < MiniTest::Test
   def test_create_parts_from_response_returns_a_single_part_when_not_multipart_response
     response = {}
     response.stubs(:header => { "content-type" => ['text/plain']})
-    response.stubs(:headers => { "content-type" => ['text/plain']})
+    response.stubs(:headers => { "Content-Type" => 'text/plain'})
     response.stubs(:body => "fakebody")
 
     parts = @client.create_parts_from_response(response)


### PR DESCRIPTION
See inlined explanation