### PR TITLE
Rets spec indicates getobject object ids must be seperated with colon…

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -180,7 +180,7 @@ module Rets
     def objects(object_ids, opts = {})
       response = case object_ids
         when String then fetch_object(object_ids, opts)
-        when Array  then fetch_object(object_ids.join(","), opts)
+        when Array  then fetch_object(object_ids.join(":"), opts)
         else raise ArgumentError, "Expected instance of String or Array, but got #{object_ids.inspect}."
       end
 

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -217,10 +217,10 @@ class TestClient < MiniTest::Test
   end
 
   def test_objects_handle_array_argument
-    @client.expects(:fetch_object).with("1,2", :foo => :bar)
+    @client.expects(:fetch_object).with("1:2:3", :foo => :bar)
     @client.stubs(:create_parts_from_response)
 
-    @client.objects([1,2], :foo => :bar)
+    @client.objects([1,2,3], :foo => :bar)
   end
 
   def test_objects_raises_on_other_arguments


### PR DESCRIPTION
…s, not commas