### PR TITLE
Adjust object metadata

### DIFF
--- a/lib/rets/metadata/rets_object.rb
+++ b/lib/rets/metadata/rets_object.rb
@@ -10,10 +10,11 @@ module Rets
       end
 
       def self.build(rets_object_fragment)
-        name = rets_object_fragment["VisibleName"]
-        mime_type = rets_object_fragment["MIMEType"]
-        description = rets_object_fragment["Description"]
-        new(name, mime_type, description)
+        rets_object_fragment = downcase_hash_keys(rets_object_fragment)
+        name = rets_object_fragment["visiblename"]
+        mime_type = rets_object_fragment["mimetype"]
+        description = rets_object_fragment["description"]
+        new(object_type, name, mime_type, description)
       end
 
       def print_tree(out = $stdout)
@@ -26,6 +27,11 @@ module Rets
         name == other.name &&
           mime_type == other.mime_type &&
           description == other.description
+      end
+
+      private
+      def self.downcase_hash_keys(hash)
+        Hash[hash.map { |k, v| [k.downcase, v] }]
       end
     end
   end

--- a/lib/rets/metadata/rets_object.rb
+++ b/lib/rets/metadata/rets_object.rb
@@ -1,12 +1,13 @@
 module Rets
   module Metadata
     class RetsObject
-      attr_reader :name, :mime_type, :description
+      attr_reader :name, :mime_type, :description, :type
 
-      def initialize(name, mime_type, description)
+      def initialize(type, name, mime_type, description)
         @name = name
         @mime_type = mime_type
         @description = description
+        @type = type
       end
 
       def self.build(rets_object_fragment)
@@ -14,12 +15,14 @@ module Rets
         name = rets_object_fragment["visiblename"]
         mime_type = rets_object_fragment["mimetype"]
         description = rets_object_fragment["description"]
-        new(object_type, name, mime_type, description)
+        type = rets_object_fragment['objecttype']
+        new(type, name, mime_type, description)
       end
 
       def print_tree(out = $stdout)
-        out.puts "  Object: #{name}"
-        out.puts "    MimeType: #{mime_type}"
+        out.puts "  Object: #{type}"
+        out.puts "    Visible Name: #{name}"
+        out.puts "    Mime Type: #{mime_type}"
         out.puts "    Description: #{description}"
       end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -309,7 +309,8 @@ Resource: Properties (Key Field: matrix_unique_key)
       Types:
         Quarterly -> Q
         Annually -> A
-  Object: Photo
-    MimeType: photo/jpg
+  Object: HiRes
+    Visible Name: Photo
+    Mime Type: photo/jpg
     Description: photo description
 EOF

--- a/test/test_metadata.rb
+++ b/test/test_metadata.rb
@@ -58,7 +58,7 @@ class TestMetadata < MiniTest::Test
     ]
 
     rets_objects = [
-      Rets::Metadata::RetsObject.new("Photo", "photo/jpg", "photo description")
+      Rets::Metadata::RetsObject.new("HiRes", "Photo", "photo/jpg", "photo description")
     ]
 
     resource = Rets::Metadata::Resource.new(resource_id, "matrix_unique_key", rets_classes, rets_objects)

--- a/test/test_metadata_object.rb
+++ b/test/test_metadata_object.rb
@@ -15,6 +15,14 @@ class TestMetadataObject < MiniTest::Test
     assert_equal(
       Rets::Metadata::RetsObject.build(object_fragment),
       Rets::Metadata::RetsObject.new(name, mime_type, description)
+  def test_rets_object_building_not_case_dependent
+    object_fragment = {
+      "MiMeTyPe" => "image/jpeg"
+    }
+
+    assert_equal(
+      Rets::Metadata::RetsObject.build(object_fragment).mime_type,
+      "image/jpeg"
     )
   end
 end

--- a/test/test_metadata_object.rb
+++ b/test/test_metadata_object.rb
@@ -8,9 +8,10 @@ class TestMetadataObject < MiniTest::Test
     object_type = "type"
 
     object_fragment = {
-        "VisibleName" => name,
-        "MIMEType"    => mime_type,
-        "Description" => description,
+      "ObjectType" => object_type,
+      "VisibleName" => name,
+      "MIMEType"    => mime_type,
+      "Description" => description,
     }
 
     assert_equal(

--- a/test/test_metadata_object.rb
+++ b/test/test_metadata_object.rb
@@ -5,6 +5,7 @@ class TestMetadataObject < MiniTest::Test
     name = "Name"
     mime_type = "mimetype"
     description = "description"
+    object_type = "type"
 
     object_fragment = {
         "VisibleName" => name,
@@ -14,7 +15,10 @@ class TestMetadataObject < MiniTest::Test
 
     assert_equal(
       Rets::Metadata::RetsObject.build(object_fragment),
-      Rets::Metadata::RetsObject.new(name, mime_type, description)
+      Rets::Metadata::RetsObject.new(object_type, name, mime_type, description)
+    )
+  end
+
   def test_rets_object_building_not_case_dependent
     object_fragment = {
       "MiMeTyPe" => "image/jpeg"


### PR DESCRIPTION
This PR adds some adjustments to object metadata parsing and display.

First thing I noticed is that some rets servers use `MimeType` as the key for the object mime type. The gem was not picking this up in the metadata because it assumes the key to be `MIMEType`.

Also, the object type seems to be the differentiator between objects while the visible name is often equal to object type, sometimes just a generic name like `Photo`, or sometimes blank. So, I have made the object type the title in the printed metadata.

It may be useful to downcase hash keys when grabbing values for other fragments (classes, tables, etc.) but I didn't want to go that far unless it was necessary.