### PR TITLE
throw first exception when retrying requests fails

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -83,7 +83,7 @@ module Rets
       find_with_given_retry(retries, opts)
     end
 
-    def find_with_given_retry(retries, opts)
+    def find_with_given_retry(retries, opts, original_exception = nil)
       begin
         find_every(opts)
       rescue NoRecordsFound => e
@@ -91,13 +91,13 @@ module Rets
           client_progress.no_records_found
           opts[:count] == COUNT.only ? 0 : []
         else
-          handle_find_failure(retries, opts, e)
+          handle_find_failure(retries, opts, original_exception || e)
         end
       rescue InvalidRequest, HttpError => e
-        handle_find_failure(retries, opts, e)
+        handle_find_failure(retries, opts, original_exception || e)
       rescue AuthorizationFailure => e
         login
-        handle_find_failure(retries, opts, e)
+        handle_find_failure(retries, opts, original_exception || e)
       end
     end
 
@@ -106,7 +106,7 @@ module Rets
         retries += 1
         client_progress.find_with_retries_failed_a_retry(e, retries)
         clean_setup
-        find_with_given_retry(retries, opts)
+        find_with_given_retry(retries, opts, e)
       else
         client_progress.find_with_retries_exceeded_retry_count(e)
         raise e

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -187,11 +187,16 @@ class TestClient < MiniTest::Test
     @client.find(:all, :foo => :bar)
   end
 
-  def test_find_eventually_reraises_errors
-    @client.stubs(:find_every).raises(Rets::AuthorizationFailure.new(401, 'Not Authorized'))
+  def test_find_eventually_reraises_first_error
+    @client.stubs(:find_every).raises(
+      Rets::InvalidRequest.new(20134, 'Not Found')
+    ).then.raises(
+      Rets::AuthorizationFailure.new(401, 'Not Authorized')
+    )
+
     @client.stubs(:login)
 
-    assert_raises Rets::AuthorizationFailure do
+    assert_raises Rets::InvalidRequest do
       @client.find(:all, :foo => :bar)
     end
   end


### PR DESCRIPTION
When performing bad queries rets servers often log you out.

I've been burned quite often where I have an invalid query but the exception I see is an authorization exception from one of the retries.

It makes more sense to me to raise the first exception when retrying queries.