### PR TITLE
handle invalid encodings from any http call

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -138,7 +138,7 @@ module Rets
         Parser::Compact.get_count(res.body)
       else
         results = Parser::Compact.parse_document(
-          res.body.encode("UTF-8", res.body.encoding, :invalid => :replace, :undef => :replace)
+          res.body
         )
         if opts[:resolve]
           rets_class = find_rets_class(opts[:search_type], opts[:class])
@@ -330,11 +330,16 @@ module Rets
     end
 
     def http_get(url, params=nil, extra_headers={})
-      @http_client.http_get(url, params, extra_headers)
+      clean_response(@http_client.http_get(url, params, extra_headers))
+    end
+
+    def clean_response(res)
+      res.body.encode!("UTF-8", res.body.encoding, :invalid => :replace, :undef => :replace)
+      res
     end
 
     def http_post(url, params, extra_headers = {})
-      @http_client.http_post(url, params, extra_headers)
+      clean_response(@http_client.http_post(url, params, extra_headers))
     end
 
     def tries

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -132,7 +132,7 @@ class TestClient < MiniTest::Test
     response = mock
     response.stubs(:body).returns("An ascii string".encode("binary", "UTF-8"))
 
-    assert_equal @client.clean_response(response), "An ascii string"
+    assert_equal @client.clean_response(response).body, "An ascii string"
   end
 
   def test_response_text_encoding_from_utf_8
@@ -140,7 +140,7 @@ class TestClient < MiniTest::Test
     response = mock
     response.stubs(:body).returns("Some string with non-ascii characters \u0119")
 
-    assert_equal @client.clean_response(response), "Some string with non-ascii characters \u0119"
+    assert_equal @client.clean_response(response).body, "Some string with non-ascii characters \u0119"
 
   end
 
@@ -149,7 +149,7 @@ class TestClient < MiniTest::Test
     response = mock
     response.stubs(:body).returns("Some string with non-utf-8 characters \xC2")
 
-    assert_equal @client.clean_response(response), "Some string with non-utf-8 characters \uFFFD"
+    assert_equal @client.clean_response(response).body, "Some string with non-utf-8 characters \uFFFD"
   end
 
   def test_find_retries_when_receiving_no_records_found

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -129,38 +129,27 @@ class TestClient < MiniTest::Test
 
   def test_response_text_encoding_from_ascii
     @client.stubs(:capability_url).with("Search").returns("search_url")
-
     response = mock
-    response.stubs(:body).returns(("An ascii string").encode("binary", "UTF-8"))
-    @client.stubs(:http_post).with("search_url", anything).returns(response)
+    response.stubs(:body).returns("An ascii string".encode("binary", "UTF-8"))
 
-    Rets::Parser::Compact.expects(:parse_document).with("An ascii string")
-
-    @client.find_every(:search_type => "Foo", :class => "Bar")
+    assert_equal @client.clean_response(response), "An ascii string"
   end
 
   def test_response_text_encoding_from_utf_8
     @client.stubs(:capability_url).with("Search").returns("search_url")
-
     response = mock
     response.stubs(:body).returns("Some string with non-ascii characters \u0119")
-    @client.stubs(:http_post).with("search_url", anything).returns(response)
 
-    Rets::Parser::Compact.expects(:parse_document).with("Some string with non-ascii characters \u0119")
+    assert_equal @client.clean_response(response), "Some string with non-ascii characters \u0119"
 
-    @client.find_every(:search_type => "Foo", :class => "Bar")
   end
 
   def test_response_text_encoding_from_utf_16
     @client.stubs(:capability_url).with("Search").returns("search_url")
-
     response = mock
     response.stubs(:body).returns("Some string with non-utf-8 characters \xC2")
-    @client.stubs(:http_post).with("search_url", anything).returns(response)
 
-    Rets::Parser::Compact.expects(:parse_document).with("Some string with non-utf-8 characters \uFFFD")
-
-    @client.find_every(:search_type => "Foo", :class => "Bar")
+    assert_equal @client.clean_response(response), "Some string with non-utf-8 characters \uFFFD"
   end
 
   def test_find_retries_when_receiving_no_records_found


### PR DESCRIPTION
we were only fix encodings on one specific use of `http_post`, this generalizes the encoding fixes for everything.