### PR TITLE
Fix invalid codepoints in doubly-encoded character references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.10.1 / 2016-05-04
+
+* fix: handle invalid codepoints in character references
+
 ### 0.10.0 / 2016-02-29
 
 * fix: ensure cookie store exists #133

--- a/lib/rets.rb
+++ b/lib/rets.rb
@@ -3,7 +3,7 @@ require 'digest/md5'
 require 'nokogiri'
 
 module Rets
-  VERSION = '0.10.0'
+  VERSION = '0.10.1'
 
   HttpError            = Class.new(StandardError)
   MalformedResponse    = Class.new(ArgumentError)

--- a/rets.gemspec
+++ b/rets.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: rets 0.10.1.20160503204800 ruby lib
+# stub: rets 0.10.1.20160503205231 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "rets"
-  s.version = "0.10.1.20160503204800"
+  s.version = "0.10.1.20160503205231"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]

--- a/rets.gemspec
+++ b/rets.gemspec
@@ -1,23 +1,23 @@
 # -*- encoding: utf-8 -*-
-# stub: rets 0.10.0.20160229122321 ruby lib
+# stub: rets 0.10.1.20160503204800 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "rets"
-  s.version = "0.10.0.20160229122321"
+  s.version = "0.10.1.20160503204800"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Estately, Inc. Open Source"]
-  s.date = "2016-02-29"
+  s.date = "2016-05-03"
   s.description = "[![Build Status](https://secure.travis-ci.org/estately/rets.png?branch=master)](http://travis-ci.org/estately/rets)\nA pure-ruby library for fetching data from [RETS] servers.\n\n[RETS]: http://www.rets.org"
   s.email = ["opensource@estately.com"]
   s.executables = ["rets"]
   s.extra_rdoc_files = ["CHANGELOG.md", "Manifest.txt", "README.md"]
-  s.files = [".gemtest", "CHANGELOG.md", "Manifest.txt", "README.md", "Rakefile", "bin/rets", "example/connect.rb", "example/get-photos.rb", "example/get-property.rb", "lib/rets.rb", "lib/rets/client.rb", "lib/rets/client_progress_reporter.rb", "lib/rets/http_client.rb", "lib/rets/locking_http_client.rb", "lib/rets/measuring_http_client.rb", "lib/rets/metadata.rb", "lib/rets/metadata/caching.rb", "lib/rets/metadata/containers.rb", "lib/rets/metadata/file_cache.rb", "lib/rets/metadata/json_serializer.rb", "lib/rets/metadata/lookup_table.rb", "lib/rets/metadata/lookup_type.rb", "lib/rets/metadata/marshal_serializer.rb", "lib/rets/metadata/multi_lookup_table.rb", "lib/rets/metadata/null_cache.rb", "lib/rets/metadata/resource.rb", "lib/rets/metadata/rets_class.rb", "lib/rets/metadata/rets_object.rb", "lib/rets/metadata/root.rb", "lib/rets/metadata/table.rb", "lib/rets/metadata/table_factory.rb", "lib/rets/metadata/yaml_serializer.rb", "lib/rets/parser/compact.rb", "lib/rets/parser/error_checker.rb", "lib/rets/parser/multipart.rb", "test/fixtures.rb", "test/helper.rb", "test/test_caching.rb", "test/test_client.rb", "test/test_error_checker.rb", "test/test_file_cache.rb", "test/test_http_client.rb", "test/test_json_serializer.rb", "test/test_locking_http_client.rb", "test/test_marshal_serializer.rb", "test/test_metadata.rb", "test/test_metadata_class.rb", "test/test_metadata_lookup_table.rb", "test/test_metadata_lookup_type.rb", "test/test_metadata_multi_lookup_table.rb", "test/test_metadata_object.rb", "test/test_metadata_resource.rb", "test/test_metadata_root.rb", "test/test_metadata_table.rb", "test/test_metadata_table_factory.rb", "test/test_parser_compact.rb", "test/test_parser_multipart.rb", "test/test_yaml_serializer.rb", "test/vcr_cassettes/unauthorized_response.yml"]
+  s.files = ["CHANGELOG.md", "Manifest.txt", "README.md", "Rakefile", "bin/rets", "example/connect.rb", "example/get-photos.rb", "example/get-property.rb", "lib/rets.rb", "lib/rets/client.rb", "lib/rets/client_progress_reporter.rb", "lib/rets/http_client.rb", "lib/rets/locking_http_client.rb", "lib/rets/measuring_http_client.rb", "lib/rets/metadata.rb", "lib/rets/metadata/caching.rb", "lib/rets/metadata/containers.rb", "lib/rets/metadata/file_cache.rb", "lib/rets/metadata/json_serializer.rb", "lib/rets/metadata/lookup_table.rb", "lib/rets/metadata/lookup_type.rb", "lib/rets/metadata/marshal_serializer.rb", "lib/rets/metadata/multi_lookup_table.rb", "lib/rets/metadata/null_cache.rb", "lib/rets/metadata/resource.rb", "lib/rets/metadata/rets_class.rb", "lib/rets/metadata/rets_object.rb", "lib/rets/metadata/root.rb", "lib/rets/metadata/table.rb", "lib/rets/metadata/table_factory.rb", "lib/rets/metadata/yaml_serializer.rb", "lib/rets/parser/compact.rb", "lib/rets/parser/error_checker.rb", "lib/rets/parser/multipart.rb", "test/fixtures.rb", "test/helper.rb", "test/test_caching.rb", "test/test_client.rb", "test/test_error_checker.rb", "test/test_file_cache.rb", "test/test_http_client.rb", "test/test_json_serializer.rb", "test/test_locking_http_client.rb", "test/test_marshal_serializer.rb", "test/test_metadata.rb", "test/test_metadata_class.rb", "test/test_metadata_lookup_table.rb", "test/test_metadata_lookup_type.rb", "test/test_metadata_multi_lookup_table.rb", "test/test_metadata_object.rb", "test/test_metadata_resource.rb", "test/test_metadata_root.rb", "test/test_metadata_table.rb", "test/test_metadata_table_factory.rb", "test/test_parser_compact.rb", "test/test_parser_multipart.rb", "test/test_yaml_serializer.rb", "test/vcr_cassettes/unauthorized_response.yml"]
   s.homepage = "http://github.com/estately/rets"
   s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.md"]
-  s.rubygems_version = "2.4.5.1"
+  s.rubygems_version = "2.5.1"
   s.summary = "[![Build Status](https://secure.travis-ci.org/estately/rets.png?branch=master)](http://travis-ci.org/estately/rets) A pure-ruby library for fetching data from [RETS] servers"
 
   if s.respond_to? :specification_version then
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<mocha>, ["~> 0.11"])
       s.add_development_dependency(%q<vcr>, ["~> 2.2"])
       s.add_development_dependency(%q<webmock>, ["~> 1.8"])
-      s.add_development_dependency(%q<hoe>, ["~> 3.13"])
+      s.add_development_dependency(%q<hoe>, ["~> 3.15"])
     else
       s.add_dependency(%q<httpclient>, ["~> 2.7.0"])
       s.add_dependency(%q<http-cookie>, ["~> 1.0.0"])
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<mocha>, ["~> 0.11"])
       s.add_dependency(%q<vcr>, ["~> 2.2"])
       s.add_dependency(%q<webmock>, ["~> 1.8"])
-      s.add_dependency(%q<hoe>, ["~> 3.13"])
+      s.add_dependency(%q<hoe>, ["~> 3.15"])
     end
   else
     s.add_dependency(%q<httpclient>, ["~> 2.7.0"])
@@ -50,6 +50,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<mocha>, ["~> 0.11"])
     s.add_dependency(%q<vcr>, ["~> 2.2"])
     s.add_dependency(%q<webmock>, ["~> 1.8"])
-    s.add_dependency(%q<hoe>, ["~> 3.13"])
+    s.add_dependency(%q<hoe>, ["~> 3.15"])
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -266,6 +266,14 @@ SAMPLE_COMPACT_WITH_SPECIAL_CHARS_2 = <<EOF
 </RETS>
 EOF
 
+SAMPLE_COMPACT_WITH_DOUBLY_ENCODED_BAD_CHARACTER_REFERENCES = <<EOF
+<RETS ReplyCode=\"0\" ReplyText=\"Operation Success.\">
+  <DELIMITER value=\"09\" />
+  <COLUMNS>	PublicRemarksNew	WindowCoverings	YearBuilt	Zoning	ZoningCompatibleYN	</COLUMNS>
+  <DATA>	foo &amp;#56324; bar		1999	00		</DATA>
+</RETS>
+EOF
+
 SAMPLE_PROPERTY_WITH_LOTS_OF_COLUMNS = <<EOF
 <RETS ReplyCode=\"0\" ReplyText=\"Operation Success.\">
   <DELIMITER value=\"09\" />

--- a/test/test_parser_compact.rb
+++ b/test/test_parser_compact.rb
@@ -86,9 +86,30 @@ class TestParserCompact < MiniTest::Test
     assert_equal "text with <tag>", rows.last["PublicRemarksNew"]
   end
 
+  def test_parse_doubly_encoded_bad_character_references
+    rows = Rets::Parser::Compact.parse_document(SAMPLE_COMPACT_WITH_DOUBLY_ENCODED_BAD_CHARACTER_REFERENCES)
+    assert_equal "foo  bar", rows.last["PublicRemarksNew"]
+  end
+
   def test_parse_property_with_lots_of_columns
     row = Rets::Parser::Compact.parse_document(SAMPLE_PROPERTY_WITH_LOTS_OF_COLUMNS).first
     assert_equal 800, row.keys.size
     assert_equal 800.times.map { |x| "K%03d" % x }, row.keys
+  end
+
+  def test_safely_decode_character_references!
+    assert_decoded "a", "&#97;"
+    assert_decoded "a", "&#097;"
+    assert_decoded "a", "&#x61;"
+    assert_decoded "a", "&#x061;"
+    assert_decoded "", "&#xDC04;"
+    assert_decoded "", "&#56324;"
+    assert_decoded "", "&#x2000FF;"
+  end
+
+
+  def assert_decoded(a, b)
+    recoded = Rets::Parser::Compact.safely_decode_character_references!(b)
+    assert_equal a, recoded
   end
 end


### PR DESCRIPTION
This PR is motivated by an observation by @hfaulds that documents with badly-encoded HTML character references such as `&#56256;&#56324;` will cause the library to raise the following error:

    RangeError: invalid codepoint 0xDBC0 in UTF-8
            from /usr/lib/ruby/2.3.0/cgi/util.rb:79:in `chr'
            from /usr/lib/ruby/2.3.0/cgi/util.rb:79:in `block in unescapeHTML'
            from /usr/lib/ruby/2.3.0/cgi/util.rb:66:in `gsub'
            from /usr/lib/ruby/2.3.0/cgi/util.rb:66:in `unescapeHTML'

Character references are used to specify any UTF-8 character in HTML by codepoint.

If an invalid codepoint is given anywhere in a string, `CGI.unescape_html` will raise a RangeError.

The method added here will examine a string for character references, and when found, replace them with the decoded UTF-8 character. If the given codepoint is invalid, it will replace the character reference with the empty string. In Rets, this problem can arise when a parsed document contains a character reference to an invalid codepoint that is HTML-encoded two times. Nokogiri will decode it the first time, passing through the now singly-encoded invalid character reference to `CGI.unescape_html`.