### PR TITLE
Fix metadata fetching

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -270,7 +270,7 @@ module Rets
                         "Type"   => "METADATA-#{type}",
                         "ID"     => "0"
                       })
-      clean_response(res.body)
+      clean_response(res).body
     end
 
     # The capabilies as provided by the RETS server during login.


### PR DESCRIPTION
https://github.com/estately/rets/pull/185 introduced a bug in metadata fetching which exceptions.

We didn't notice initially because of caching.

The test stub out this method.