### PR TITLE
RFC Create mock http client to avoid partial stubbing

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -19,9 +19,9 @@ module Rets
       @login_url           = options[:login_url]
       @cached_metadata     = options[:metadata]
       @cached_capabilities = options[:capabilities]
-      @logger              = options[:logger] || FakeLogger.new
+      @logger              = options.fetch(:logger, FakeLogger.new)
       @client_progress     = ClientProgressReporter.new(logger, options[:stats_collector], options[:stats_prefix])
-      @http_client         = Rets::HttpClient.from_options(options, logger)
+      @http_client         = options.fetch(:http_client, Rets::HttpClient.from_options(options, logger))
       @caching             = Metadata::Caching.make(options)
     end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -33,6 +33,14 @@ CAPABILITIES = <<-XML
 </RETS>
 XML
 
+REAL_CAPABILITIES = <<-XML
+<RETS ReplyCode="0" ReplyText="OK">
+  <RETS-RESPONSE>
+    Action = http://example.com/RETS/Action
+  </RETS-RESPONSE>
+</RETS>
+XML
+
 COUNT_ONLY = <<XML
 <RETS ReplyCode="0" ReplyText="Success">
 <COUNT Records="1234" />

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,3 +12,26 @@ VCR.configure do |c|
   c.hook_into :webmock
 end
 
+class MockHttpClient
+  attr_reader :stubbed_urls
+
+  def initialize(stubbed_urls)
+    @stubbed_urls = stubbed_urls
+  end
+
+  def http_post(url, params, extra_headers)
+    Response.new(stubbed_urls.fetch(url))
+  end
+
+  def http_get(url, params, extra_headers)
+    Response.new(stubbed_urls.fetch(url))
+  end
+
+  class Response
+    attr_reader :body
+
+    def initialize(body)
+      @body = body
+    end
+  end
+end


### PR DESCRIPTION
Motivated by https://github.com/estately/rets/pull/188

The partial stubbing in our tests was hiding an exception.

I wanted to try using some dependency injection and real objects to help make our tests capture these scenarios.
