### PR TITLE
optionally login after exception default to logging in

### DIFF
--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -9,11 +9,13 @@ module Rets
 
     def initialize(options)
       @options = options
-      @capabilities = nil
       clean_setup
     end
 
     def clean_setup
+      if options.fetch(:login_after_error, false)
+        @capabilities = nil
+      end
       @metadata            = nil
       @tries               = nil
       @login_url           = options[:login_url]

--- a/lib/rets/client.rb
+++ b/lib/rets/client.rb
@@ -13,7 +13,7 @@ module Rets
     end
 
     def clean_setup
-      if options.fetch(:login_after_error, false)
+      if options.fetch(:login_after_error, true)
         @capabilities = nil
       end
       @metadata            = nil


### PR DESCRIPTION
Based on @summera's comments in https://github.com/estately/rets/pull/183 I think this is probably the right way to solve the exception problem and retry properly.

We can prevent logging in after retries in specific mlses if there are any worries about it.