### PR TITLE
Fixed building Resource metadata when Object metadata wasn't loaded

### DIFF
--- a/lib/rets/metadata/resource.rb
+++ b/lib/rets/metadata/resource.rb
@@ -29,7 +29,12 @@ module Rets
       end
 
       def self.find_rets_objects(metadata, resource_id)
-        metadata[:object].select { |object| object.resource == resource_id }.map(&:objects).flatten
+        objects = metadata[:object]
+        if objects
+          objects.select { |object| object.resource == resource_id }.map(&:objects).flatten
+        else
+          []
+        end
       end
 
       def self.build_lookup_tree(resource_id, metadata)

--- a/test/test_metadata_resource.rb
+++ b/test/test_metadata_resource.rb
@@ -53,12 +53,20 @@ class TestMetadataResource < MiniTest::Test
     assert_equal([rets_object], objects)
   end
 
+  def test_resource_build_objects_when_objects_were_not_loaded
+    resource_id = "id"
+    metadata    = {} # doesn't contain metadata for :object key
+
+    objects = Rets::Metadata::Resource.build_objects(resource_id, metadata)
+    assert_equal [], objects
+  end
+
   def test_resource_build
     fragment = { "ResourceID" => "test" }
 
     lookup_types = stub(:lookup_types)
     classes = stub(:classes)
-    objects = stub(:classes)
+    objects = stub(:objects)
     metadata = stub(:metadata)
 
     Rets::Metadata::Resource.stubs(:build_lookup_tree => lookup_types)


### PR DESCRIPTION
Some RETS servers doesn't support OBJECT metadata and we can skip it by providing custom list of types to `Rets::Client#metadata`.
Resource building still should work when we skipped loading of OBJECT metadata. And it was working before https://github.com/estately/rets/pull/168