### PR TITLE
adds basic markdown formatting to tree output

### DIFF
--- a/lib/rets/metadata/lookup_table.rb
+++ b/lib/rets/metadata/lookup_table.rb
@@ -22,7 +22,7 @@ module Rets
       #
       # [out] The file to print to.  Defaults to $stdout.
       def print_tree(out = $stdout)
-        out.puts "    LookupTable: #{name}"
+        out.puts "### LookupTable: #{name}"
         out.puts "      Resource: #{resource_id}"
         out.puts "      Required: #{table_fragment['Required']}"
         out.puts "      Searchable: #{ table_fragment["Searchable"] }"
@@ -30,7 +30,7 @@ module Rets
         out.puts "      ShortName: #{ table_fragment["ShortName"] }"
         out.puts "      LongName: #{ long_name }"
         out.puts "      StandardName: #{ table_fragment["StandardName"] }"
-        out.puts "      Types:"
+        out.puts "####  Types:"
 
         lookup_types.each do |lookup_type|
           lookup_type.print_tree(out)

--- a/lib/rets/metadata/multi_lookup_table.rb
+++ b/lib/rets/metadata/multi_lookup_table.rb
@@ -22,7 +22,7 @@ module Rets
       #
       # [out] The file to print to.  Defaults to $stdout.
       def print_tree(out = $stdout)
-        out.puts "    MultiLookupTable: #{name}"
+        out.puts "### MultiLookupTable: #{name}"
         out.puts "      Resource: #{resource_id}"
         out.puts "      Required: #{table_fragment['Required']}"
         out.puts "      Searchable: #{ table_fragment["Searchable"] }"

--- a/lib/rets/metadata/resource.rb
+++ b/lib/rets/metadata/resource.rb
@@ -85,7 +85,7 @@ module Rets
       #
       # [out] The file to print to.  Defaults to $stdout.
       def print_tree(out = $stdout)
-        out.puts "Resource: #{id} (Key Field: #{key_field})"
+        out.puts "# Resource: #{id} (Key Field: #{key_field})"
         rets_classes.each do |rets_class|
           rets_class.print_tree(out)
         end

--- a/lib/rets/metadata/rets_class.rb
+++ b/lib/rets/metadata/rets_class.rb
@@ -41,7 +41,7 @@ module Rets
       #
       # [out] The file to print to.  Defaults to $stdout.
       def print_tree(out = $stdout)
-        out.puts "  Class: #{name}"
+        out.puts "## Class: #{name}"
         out.puts "    Visible Name: #{visible_name}"
         out.puts "    Description : #{description}"
         tables.each do |table|

--- a/lib/rets/metadata/table.rb
+++ b/lib/rets/metadata/table.rb
@@ -15,7 +15,7 @@ module Rets
       #
       # [out] The file to print to.  Defaults to $stdout.
       def print_tree(out = $stdout)
-        out.puts "    Table: #{name}"
+        out.puts "### Table: #{name}"
         out.puts "      Resource: #{resource_id}"
         out.puts "      ShortName: #{ table_fragment["ShortName"] }"
         out.puts "      LongName: #{ long_name }"


### PR DESCRIPTION
This somewhat invasively changes the output format of the ['print_tree'](https://github.com/estately/rets/blob/master/lib/rets/metadata/root.rb#L112) method, in some cases replacing the leading whitespace with markdown title characters.  

I've found it nice to dump the metadata into our project and link to the Github rendered markdown in documentation. 

If you're not keen on this PR as it is, would you be open to me adding a switch to use markdown rendering an additional optional argument to the `print_tree` methods?