### PR TITLE
add resolve example

### DIFF
--- a/example/get-property-using-resolve.rb
+++ b/example/get-property-using-resolve.rb
@@ -1,0 +1,22 @@
+require 'rets'
+
+# Some MLS's don't display actual values in many fields. Instead they return lookup values
+# that you must query the metadata with, to find the actual value you're looking for.
+
+# Example: For the Status field, you might see something like this: "QAFID99930002233300003DDFFFFAAW".
+# This gem enables you to exchange this value, using the metadata, on the fly for the human-readable
+# translation (Like "Active")
+
+# Prepare a normal "find" call
+# Pass resolve: true and the gem will reveal the human-readable values in the response
+
+property = client.find :first, {
+  search_type: 'Property',
+  class: 'CLASS_NAME',
+  query: 'RETS_QUERY',
+  resolve: true
+}
+
+puts 'received property: '
+puts property.inspect
+client.logout


### PR DESCRIPTION
I didn't know about this cool feature of the gem earlier this week and it's a big one. Flex MLS systems use lookups like crazy so I figured it might be nice to add an example of this one. 