### PR TITLE
Bump httpclient version specifier to >= 2.7.0

### DIFF
--- a/rets.gemspec
+++ b/rets.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rets"
-  s.version = "0.11.0.20170130173054"
+  s.version = "0.11.0.20190926203900"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httpclient>, ["~> 2.7.0"])
+      s.add_runtime_dependency(%q<httpclient>, [">= 2.7.0"])
       s.add_runtime_dependency(%q<http-cookie>, ["~> 1.0.0"])
       s.add_runtime_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])


### PR DESCRIPTION
Version 2.8 of `httpclient` has been out for a while now (since April 2016), and we're running into issues with other gems requiring v2.8 and rets not supporting it.

This PR specifies `>= 2.7.0` so there is no impact for people who don't _need_ to upgrade.